### PR TITLE
Initial implementation of a runtime configuration mechanism 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,4 @@ _html/
 .initialize_new_project.sh
 
 # Parsl log files
-runinfo/
+run_logs/

--- a/example_runtime_config.toml
+++ b/example_runtime_config.toml
@@ -1,0 +1,14 @@
+
+# All values set here will be applied to the resource configuration prior to 
+# calling parsl.load(config). Even if the key does't exist in the resource
+# config, it will be added with the value defined here.
+[resource_config_modifiers]
+checkpoint_mode = "task_exit"
+
+
+# Values in the apps.XXX section will be passed as a dictionary to the corresponding
+# app. e.g. apps.create_uri_manifest will be passed to the create_uri_manifest app.
+[apps.create_uri_manifest]
+# The path to the staging directory
+# e.g. "/gscratch/dirac/kbmod/workflow/staging"
+staging_directory = "/home/drew/code/kbmod-wf/dev_staging"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "parsl", # The primary workflow orchestration tool
+    "toml", # Used to read runtime configuration files
 ]
 
 [project.urls]

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -3,6 +3,7 @@ import datetime
 from parsl import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import LocalProvider, SlurmProvider
+from parsl.utils import get_all_checkpoints
 
 walltimes = {
     "compute-bigmem": "01:00:00",  # change this to be appropriate
@@ -11,6 +12,9 @@ walltimes = {
 
 def klone_resource_config():
     return Config(
+        app_cache=True,
+        checkpoint_mode="task_exit",
+        checkpoint_files=get_all_checkpoints(),
         run_dir=os.path.join("/gscratch/dirac/kbmod/workflow/run_logs", datetime.date.today().isoformat()),
         executors=[
             HighThroughputExecutor(

--- a/src/kbmod_wf/utilities/__init__.py
+++ b/src/kbmod_wf/utilities/__init__.py
@@ -1,5 +1,6 @@
-from .configuration_utilities import get_resource_config
+from .configuration_utilities import get_resource_config, apply_runtime_updates
 from .executor_utilities import get_executors
 from .logger_utilities import configure_logger
+from .memoization_utilities import id_for_memo_file
 
-__all__ = ["get_resource_config", "get_executors", "configure_logger"]
+__all__ = ["apply_runtime_updates", "get_resource_config", "get_executors", "configure_logger"]

--- a/src/kbmod_wf/utilities/configuration_utilities.py
+++ b/src/kbmod_wf/utilities/configuration_utilities.py
@@ -1,4 +1,5 @@
 import platform
+import toml
 from typing import Literal
 
 from kbmod_wf.resource_configs import *
@@ -53,3 +54,32 @@ def is_running_on_wsl() -> bool:
         except FileNotFoundError:
             pass
     return False
+
+
+def apply_runtime_updates(resource_config, runtime_config):
+    """Before calling parsl.load(config), we want to modify any resource configuration
+    parameters with any runtime configuration options that might be set.
+
+    Any key in the top level of the runtime_config dictionary that matches a
+    parameter of the resource_config will be used to override the resource_config
+    value.
+
+    Parameters
+    ----------
+    resource_config : parsl.config.Config
+        The configuration object that defines the computational resources for
+        running the workflow. These are defined in the resource_configs module.
+    runtime_config : dict
+        This is the set of runtime configuration options that are used to modify
+        the workflow on a per-run basis.
+
+    Returns
+    -------
+    parsl.config.Config
+        The original resource_config updated with values from runtime_config
+    """
+    resource_config_modifiers = runtime_config.get("resource_config_modifiers", {})
+    for key, value in resource_config_modifiers.items():
+        setattr(resource_config, key, value)
+
+    return resource_config

--- a/src/kbmod_wf/utilities/memoization_utilities.py
+++ b/src/kbmod_wf/utilities/memoization_utilities.py
@@ -1,0 +1,9 @@
+import os
+from parsl.dataflow.memoization import id_for_memo
+from parsl import File
+
+
+@id_for_memo.register(File)
+def id_for_memo_file(parsl_file_object: File, output_ref: bool = False) -> bytes:
+    if output_ref and os.path.exists(parsl_file_object.filepath):
+        return pickle.dumps(parsl_file_object.filepath)


### PR DESCRIPTION
The goal here is to allow easier config modification. Currently the resource configuration is defined in code. However it doesn't allow for more dynamic runtime configuration settings that may be needed. For instance, if we need to rerun a specific task, we could set in the runtime configuration .toml file a "ignore cache" flag.

Similarly, if multiple people are running locally, instead of overwriting each other's base config, we can have a personal runtime config (that we don't commit to the repo - please excuse the example...) to let us e.g. define the location of files on our personal computers. 