### PR TITLE
Pulling kbmod-tno-scripts over to the corresponding tasks.

### DIFF
--- a/example_runtime_config.toml
+++ b/example_runtime_config.toml
@@ -12,3 +12,12 @@ checkpoint_mode = 'task_exit'
 # The path to the staging directory
 # e.g. "/gscratch/dirac/kbmod/workflow/staging"
 staging_directory = "/home/drew/code/kbmod-wf/dev_staging"
+
+[apps.reproject_wu]
+# The name of the observation site to use for reflex correction
+observation_site = "ctio"
+
+[apps.kbmod_search]
+# The path to the KBMOD search config file
+# e.g. "/gscratch/dirac/kbmod/workflow/kbmod_search_config.yaml"
+search_config_filepath = "/home/drew/code/kbmod-wf/dev_staging/search_config.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "parsl", # The primary workflow orchestration tool
     "toml", # Used to read runtime configuration files
+    "astropy", # Used for various file, date, and location manipulations
 ]
 
 [project.urls]

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -1,4 +1,5 @@
 from kbmod import ImageCollection
+from kbmod.configuration import SearchConfiguration
 
 import os
 import glob
@@ -18,248 +19,23 @@ def placeholder_ic_to_wu(ic_file=None, wu_file=None, logger=None):
     return wu_file
 
 
-def ic_to_wu(ic_file=None, uri_file=None, runtime_config={}, wu_file=None, logger=None):
+def ic_to_wu(ic_file=None, runtime_config={}, wu_file=None, logger=None):
     ic_to_wu_converter = ICtoWUConverter(
-        ic_file=ic_file, uri_file=uri_file, runtime_config=runtime_config, wu_file=wu_file, logger=logger
+        ic_file=ic_file, runtime_config=runtime_config, wu_file=wu_file, logger=logger
     )
 
     return ic_to_wu_converter.create_work_unit()
 
 
 class ICtoWUConverter:
-    def __init__(self, ic_file=None, uri_file=None, runtime_config={}, wu_file=None, logger=None):
+    def __init__(self, ic_file=None, runtime_config={}, wu_file=None, logger=None):
         self.ic_file = ic_file
-        self.uri_file = uri_file
         self.runtime_config = runtime_config
         self.wu_file = wu_file
         self.logger = logger
 
         self.overwrite = self.runtime_config.get("overwrite", False)
         self.search_config = self.runtime_config.get("search_config", None)
-
-        # Default to 8 workers if not in the config. Value must be 0<num workers<65.
-        # self.n_workers = np.max(1, np.min(self.runtime_config.get("n_workers", 8), 64))
-
-        # ! Decide if we want these from a runtime_config or exclusively read from the uri file
-        # self.patch_corners = self.runtime_config.get("patch_corners", None)
-        # self.guess_dist = self.runtime_config.get("guess_dist", None)
-        # self.pixel_scale = self.runtime_config.get("pixel_scale", None)
-
-        # ! Decide if we want these from a runtime_config or calculate each time based on self.uri_params
-        # self.image_width = self.runtime_config.get("image_width", None)
-        # self.image_height = self.runtime_config.get("image_height", None)
-
-        # self.uri_params = self._get_params_from_uri_file(uri_file=self.uri_file)
-
-        # self.pixel_scale = self.uri_params['pixel_scale']
-
-        # handle image dimensions
-        # image_width = self.image_width
-        # image_height = self.image_height
-        # if image_width == None or image_height == None:
-        #     if 'patch_box' not in self.uri_params:
-        #         raise KeyError(f'Must supply image dimensions (image_width, image_height) or #patch_size= must be in a specified URI file.')
-        #     if self.pixel_scale == None:
-        #         raise KeyError(f'When patch pixel dimensions are not specifified, the user must supply a pixel scale via the command line or the uri file.')
-
-        # image_width, image_height = self._patch_arcmin_to_pixels(
-        #     patch_size_arcmin=self.uri_params["patch_size"],
-        #     pixel_scale_arcsec_per_pix=self.pixel_scale,
-        # )
-
-        # print_debug(f'(image_width, image_height) is ({image_width}, {image_height}).')
-
-        # copied from the third "if __name__== '__main__':" block in the original
-        # print_debug(f"Creating WCS from patch")
-
-        # Create a WCS object for the patch. This will be our common reprojection WCS
-        # patch_fits_name = f"patch.fits"
-        # if 'patch_id' in self.uri_params:
-        #     patch_fits_name = f"patch_{self.uri_params['patch_id']}.fits"
-        #
-        # patch_wcs = self._create_wcs_from_corners(
-        #     self.patch_corners,
-        #     image_width,
-        #     image_height,
-        #     pixel_scale=self.pixel_scale,
-        #     save_fits=True,
-        #     filename=os.path.join(args.result_dir, patch_fits_name)
-        # )
-
-    # ======================
-    # Seems like below here in the __init__ method, belong in the `WUReprojector class` in the `reproject_wu.py` file.
-    # ======================
-
-    # else:
-    #     print(f'Reading existing WorkUnit from disk: {orig_wu_file}')
-    #     orig_wu = WorkUnit.from_fits(orig_wu_file)
-    #     elapsed = round(time.time() - last_time,1)
-    #     print_debug(f"{elapsed} seconds to read original WorkUnit ({orig_wu_file}).")
-
-    # # gather elements needed for reproject phase
-    # imgs = orig_wu.im_stack
-    # point_on_earth = EarthLocation(1814303.74553723, -5214365.7436216, -3187340.56598756, unit='m')
-
-    # # Find the EBD (estimated barycentric distance) WCS for each image
-
-    # last_time = time.time()
-    # ebd_per_image_wcs, geocentric_dists = transform_wcses_to_ebd(
-    #     orig_wu._per_image_wcs,
-    #     imgs.get_single_image(0).get_width(),
-    #     imgs.get_single_image(0).get_height(),
-    #     self.guess_dist, # args.guess_dist,
-    #     [astropy.time.Time(img.get_obstime(), format='mjd') for img in imgs.get_images()],
-    #     point_on_earth,
-    #     npoints=10,
-    #     seed=None,
-    # )
-    # elapsed = round(time.time() - last_time, 1)
-    # print_debug(f"{elapsed} seconds elapsed for transform WCS objects to EBD phase.")
-
-    # if len(orig_wu._per_image_wcs) != len(ebd_per_image_wcs):
-    #     raise ValueError(f"Number of barycentric WCS objects ({len(ebd_per_image_wcs)}) does not match the original number of images ({len(orig_wu._per_image_wcs)}).")
-
-    # # Construct a WorkUnit with the EBD WCS and provenance data
-    # print_debug(f"Creating Barycentric WorkUnit...")
-    # last_time = time.time()
-    # ebd_wu = WorkUnit(
-    #     im_stack=orig_wu.im_stack,
-    #     config=orig_wu.config,
-    #     per_image_wcs=orig_wu._per_image_wcs,
-    #     per_image_ebd_wcs=ebd_per_image_wcs,
-    #     heliocentric_distance=guess_dist,#args.guess_dist,
-    #     geocentric_distances=geocentric_dists,
-    # )
-    # elapsed = round(time.time() - last_time, 1)
-    # print_debug(f"{elapsed} seconds elapsed to create EBD WorkUnit.")
-
-    # del orig_wu # 6/7/2024 COC
-
-    # # Reproject to a common WCS using the WCS for our patch
-    # print_debug(f"Reprojecting WorkUnit with {n_workers} workers...")
-    # last_time = time.time()
-    # reprojected_wu = reprojection.reproject_work_unit(ebd_wu, patch_wcs, frame="ebd", max_parallel_processes=n_workers)
-    # elapsed = round(time.time() - last_time, 1)
-    # print_debug(f"{elapsed} seconds elapsed to create the reprojected WorkUnit.")
-    # #   print_debug("Reprojected WorkUnit created")
-
-    # # Save the reprojected WorkUnit
-    # reprojected_wu_file = os.path.join(args.result_dir, "reprojected_wu.fits")
-    # print_debug(f"Saving reprojected work unit to: {reprojected_wu_file}")
-    # last_time = time.time()
-    # reprojected_wu.to_fits(reprojected_wu_file)
-    # elapsed = round(time.time() - last_time, 1)
-    # print_debug(f"{elapsed} seconds elapsed to create the reprojected WorkUnit: {reprojected_wu_file}")
-
-    # def _get_params_from_uri_file(self, uri_file):
-    #     """
-    #     Get parameters we place into URI file as comments at the top.
-    #     Example start of URI file (6/6/2024 COC):
-    #     #desired_dates=['2019-04-02', '2019-05-07']
-    #     #dist_au=42.0
-    #     #patch_size=[20, 20]
-    #     #patch_id=5845
-    #     #patch_center_coords=(216.49999999999997, -13.500000000000005)
-    #     #patch_box=[[216.33333333333331, -13.666666666666671], [216.33333333333331, -13.333333333333337], [216.66666666666666, -13.333333333333337], [216.66666666666666, -13.666666666666671], [216.33333333333331, -13.666666666666671]]
-    #     /gscratch/dirac/DEEP/repo/DEEP/20190507/A0b/science#step6/20240425T145342Z/differenceExp/20190508/VR/VR_DECam_c0007_6300.0_2600.0/855719/differenceExp_DECam_VR_VR_DECam_c0007_6300_0_2600_0_855719_S12_DEEP_20190507_A0b_scienceHASHstep6_20240425T145342Z.fits
-    #     6/6/2024 COC
-    #     """
-    #     results = {}
-    #     with open(uri_file, 'r') as f:
-    #         for line in f:
-    #             line = line.strip()
-    #             if line == '': continue # deal with rogue blank lines or invisible double line endings
-    #             if not line.startswith('#'): break # comments section is done
-    #             line = line.lstrip('#').split('=')
-    #             lhs = line[0].strip()
-    #             rhs = line[1].strip()
-    #             try:
-    #                 rhs = eval(rhs)
-    #             except ValueError:
-    #                 self.logger.debug(f'Unable to eval() {lhs} field with value {rhs}.')
-    #                 continue
-    #             results[lhs] = rhs
-    #     return results
-
-    # def _patch_arcmin_to_pixels(self, patch_size_arcmin, pixel_scale_arcsec_per_pix):
-    #     """
-    #     Take an array of two dimensions, in arcminutes, and convert this to pixels using the supplied pixel scale (in arcseconds per pixel).
-    #     6/6/2024 COC
-    #     """
-    #     x_pixels = int(np.ceil( (patch_size_arcmin[0]*60)/pixel_scale_arcsec_per_pix ))
-    #     y_pixels = int(np.ceil( (patch_size_arcmin[1]*60)/pixel_scale_arcsec_per_pix ))
-
-    #     patch_pixels = int( np.ceil( patch_size_arcmin * 60 / pixel_scale_arcsec_per_pix ) )
-    #     patch_pixels = [ x_pixels, y_pixels ]
-
-    #     self.logger.debug(
-    #         f"Derived patch_pixels = {patch_pixels} from patch_size_arcmin={patch_size_arcmin} and pixel_scale_arcsec_per_pix={pixel_scale_arcsec_per_pix}."
-    #     )
-
-    #     return x_pixels, y_pixels
-
-    # def _create_wcs_from_corners(self, corners=None, image_width=None, image_height=None, save_fits=False, filename='output.fits', pixel_scale=None, verbose=True):
-    #     """
-    #     Create a WCS object given the RA, Dec coordinates of the four corners of the image
-    #     and the dimensions of the image in pixels. Optionally save as a FITS file.
-
-    #     Parameters:
-    #     corners (list of lists): [[RA1, Dec1], [RA2, Dec2], [RA3, Dec3], [RA4, Dec4]]
-    #     image_width (int): Width of the image in pixels; if none, pixel_scale will be used to determine size.
-    #     image_height (int): Height of the image in pixels; if none, pixel_scale will be used to determine size.
-    #     save_fits (bool): If True, save the WCS to a FITS file
-    #     filename (str): The name of the FITS file to save
-    #     pixel_scale (float): The pixel scale (in units of arcseconds per pixel); used if image_width or image_height is None.
-    #     verbose (bool): Print more messages.
-
-    #     Returns:
-    #     WCS: The World Coordinate System object for the image
-
-    #     5/6/2024 COC + ChatGPT4
-    #     """
-    #     # TODO switch to https://docs.astropy.org/en/stable/api/astropy.wcs.utils.fit_wcs_from_points.html
-    #     # Extract the corners
-    #     if verbose: print_debug(f'At the start, corners={corners}, type={type(corners)}')
-    #     if type(corners) == type((0,1)) or len(corners) == 1:
-    #         corners = corners[0]
-    #         print_debug(f'After un-tuple corners are {corners}.')
-    #     corners = np.unique(corners, axis=0) # eliminate duplicate coords in case someone passes the repeat 1st corner used for plotting 6/5/2024 COC/DO
-    #     if len(corners) != 4:
-    #         raise ValueError(f'There should be four (4) corners. We saw: {corners}')
-    #     ra = [corner[0] for corner in corners]
-    #     dec = [corner[1] for corner in corners]
-    #     #
-    #     # Calculate the central position (average of the coordinates)
-    #     center_ra = np.mean(ra)
-    #     center_dec = np.mean(dec)
-    #     #
-    #     # Calculate the pixel scale in degrees per pixel
-    #     if pixel_scale is not None:
-    #         pixel_scale_ra = pixel_scale/60/60
-    #         pixel_scale_dec = pixel_scale/60/60
-    #     else:
-    #         ra_range = (max(ra) - min(ra)) # * np.cos(np.radians(center_dec))  # Adjust RA difference for declination; do not use cos(), results in incorrect pixel scale 6/6/2024 COC
-    #         dec_range = max(dec) - min(dec)
-    #         pixel_scale_ra = ra_range / image_width
-    #         pixel_scale_dec = dec_range / image_height
-    #     if verbose: print_debug(f'Saw (RA,Dec) pixel scales ({pixel_scale_ra*60*60},{pixel_scale_dec*60*60})"/pixel. User-supplied: {pixel_scale}"/pixel.')
-    #     # Initialize a WCS object with 2 axes (RA and Dec)
-    #     wcs = WCS(naxis=2)
-    #     wcs.wcs.crpix = [image_width / 2, image_height / 2]
-    #     wcs.wcs.crval = [center_ra, center_dec]
-    #     wcs.wcs.cdelt = [-pixel_scale_ra, pixel_scale_dec]  # RA pixel scale might need to be negative (convention)
-    #     # Rotation matrix, assuming no rotation
-    #     wcs.wcs.pc = [[1, 0], [0, 1]]
-    #     # Define coordinate frame and projection
-    #     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-    #     wcs.array_shape = (image_height, image_width)
-    #     if save_fits:
-    #         # Create a new FITS file with the WCS information and a dummy data array
-    #         hdu = fits.PrimaryHDU(data=np.ones((image_height, image_width)), header=wcs.to_header())
-    #         hdulist = fits.HDUList([hdu])
-    #         hdulist.writeto(filename, overwrite=True)
-    #         print_debug(f"Saved FITS file with WCS to {filename}")
-    #     return wcs
 
     def create_work_unit(self):
         make_wu = True
@@ -275,9 +51,7 @@ class ICtoWUConverter:
             self.logger.debug(f"ImageCollection read from {self.ic_input_file}, creating work unit next.")
 
             last_time = time.time()
-            orig_wu = ic.toWorkUnit(
-                config=kbmod.configuration.SearchConfiguration.from_file(self.search_config)
-            )
+            orig_wu = ic.toWorkUnit(config=SearchConfiguration.from_file(self.search_config))
             elapsed = round(time.time() - last_time, 1)
             self.logger.info(f"{elapsed} seconds to create WorkUnit.")
 

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -23,6 +23,24 @@ def placeholder_ic_to_wu(ic_file=None, wu_file=None, logger=None):
 def ic_to_wu(
     ic_filepath: str = None, wu_filepath: str = None, runtime_config: dict = {}, logger: Logger = None
 ):
+    """This task will convert an ImageCollection to a WorkUnit.
+
+    Parameters
+    ----------
+    ic_filepath : str, optional
+        The fully resolved filepath to the input ImageCollection file, by default None
+    wu_filepath : str, optional
+        The fully resolved filepath for the output WorkUnit file, by default None
+    runtime_config : dict, optional
+        Additional configuration parameters to be used at runtime, by default {}
+    logger : Logger, optional
+        Primary logger for the workflow, by default None
+
+    Returns
+    -------
+    str
+        The fully resolved filepath of the output WorkUnit file.
+    """
     ic_to_wu_converter = ICtoWUConverter(
         ic_filepath=ic_filepath, wu_filepath=wu_filepath, runtime_config=runtime_config, logger=logger
     )

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -1,7 +1,11 @@
+from kbmod import ImageCollection
+
+import os
+import glob
 import time
 
 
-def ic_to_wu(ic_file=None, wu_file=None, logger=None):
+def placeholder_ic_to_wu(ic_file=None, wu_file=None, logger=None):
     logger.info("In the ic_to_wu task_impl")
     with open(ic_file, "r") as f:
         for line in f:
@@ -12,3 +16,275 @@ def ic_to_wu(ic_file=None, wu_file=None, logger=None):
         f.write(f"Logged: {value} - {time.time()}\n")
 
     return wu_file
+
+
+def ic_to_wu(ic_file=None, uri_file=None, runtime_config={}, wu_file=None, logger=None):
+    ic_to_wu_converter = ICtoWUConverter(
+        ic_file=ic_file, uri_file=uri_file, runtime_config=runtime_config, wu_file=wu_file, logger=logger
+    )
+
+    return ic_to_wu_converter.create_work_unit()
+
+
+class ICtoWUConverter:
+    def __init__(self, ic_file=None, uri_file=None, runtime_config={}, wu_file=None, logger=None):
+        self.ic_file = ic_file
+        self.uri_file = uri_file
+        self.runtime_config = runtime_config
+        self.wu_file = wu_file
+        self.logger = logger
+
+        self.overwrite = self.runtime_config.get("overwrite", False)
+        self.search_config = self.runtime_config.get("search_config", None)
+
+        # Default to 8 workers if not in the config. Value must be 0<num workers<65.
+        # self.n_workers = np.max(1, np.min(self.runtime_config.get("n_workers", 8), 64))
+
+        # ! Decide if we want these from a runtime_config or exclusively read from the uri file
+        # self.patch_corners = self.runtime_config.get("patch_corners", None)
+        # self.guess_dist = self.runtime_config.get("guess_dist", None)
+        # self.pixel_scale = self.runtime_config.get("pixel_scale", None)
+
+        # ! Decide if we want these from a runtime_config or calculate each time based on self.uri_params
+        # self.image_width = self.runtime_config.get("image_width", None)
+        # self.image_height = self.runtime_config.get("image_height", None)
+
+        # self.uri_params = self._get_params_from_uri_file(uri_file=self.uri_file)
+
+        # self.pixel_scale = self.uri_params['pixel_scale']
+
+        # handle image dimensions
+        # image_width = self.image_width
+        # image_height = self.image_height
+        # if image_width == None or image_height == None:
+        #     if 'patch_box' not in self.uri_params:
+        #         raise KeyError(f'Must supply image dimensions (image_width, image_height) or #patch_size= must be in a specified URI file.')
+        #     if self.pixel_scale == None:
+        #         raise KeyError(f'When patch pixel dimensions are not specifified, the user must supply a pixel scale via the command line or the uri file.')
+
+        # image_width, image_height = self._patch_arcmin_to_pixels(
+        #     patch_size_arcmin=self.uri_params["patch_size"],
+        #     pixel_scale_arcsec_per_pix=self.pixel_scale,
+        # )
+
+        # print_debug(f'(image_width, image_height) is ({image_width}, {image_height}).')
+
+        # copied from the third "if __name__== '__main__':" block in the original
+        # print_debug(f"Creating WCS from patch")
+
+        # Create a WCS object for the patch. This will be our common reprojection WCS
+        # patch_fits_name = f"patch.fits"
+        # if 'patch_id' in self.uri_params:
+        #     patch_fits_name = f"patch_{self.uri_params['patch_id']}.fits"
+        #
+        # patch_wcs = self._create_wcs_from_corners(
+        #     self.patch_corners,
+        #     image_width,
+        #     image_height,
+        #     pixel_scale=self.pixel_scale,
+        #     save_fits=True,
+        #     filename=os.path.join(args.result_dir, patch_fits_name)
+        # )
+
+    # ======================
+    # Seems like below here in the __init__ method, belong in the `WUReprojector class` in the `reproject_wu.py` file.
+    # ======================
+
+    # else:
+    #     print(f'Reading existing WorkUnit from disk: {orig_wu_file}')
+    #     orig_wu = WorkUnit.from_fits(orig_wu_file)
+    #     elapsed = round(time.time() - last_time,1)
+    #     print_debug(f"{elapsed} seconds to read original WorkUnit ({orig_wu_file}).")
+
+    # # gather elements needed for reproject phase
+    # imgs = orig_wu.im_stack
+    # point_on_earth = EarthLocation(1814303.74553723, -5214365.7436216, -3187340.56598756, unit='m')
+
+    # # Find the EBD (estimated barycentric distance) WCS for each image
+
+    # last_time = time.time()
+    # ebd_per_image_wcs, geocentric_dists = transform_wcses_to_ebd(
+    #     orig_wu._per_image_wcs,
+    #     imgs.get_single_image(0).get_width(),
+    #     imgs.get_single_image(0).get_height(),
+    #     self.guess_dist, # args.guess_dist,
+    #     [astropy.time.Time(img.get_obstime(), format='mjd') for img in imgs.get_images()],
+    #     point_on_earth,
+    #     npoints=10,
+    #     seed=None,
+    # )
+    # elapsed = round(time.time() - last_time, 1)
+    # print_debug(f"{elapsed} seconds elapsed for transform WCS objects to EBD phase.")
+
+    # if len(orig_wu._per_image_wcs) != len(ebd_per_image_wcs):
+    #     raise ValueError(f"Number of barycentric WCS objects ({len(ebd_per_image_wcs)}) does not match the original number of images ({len(orig_wu._per_image_wcs)}).")
+
+    # # Construct a WorkUnit with the EBD WCS and provenance data
+    # print_debug(f"Creating Barycentric WorkUnit...")
+    # last_time = time.time()
+    # ebd_wu = WorkUnit(
+    #     im_stack=orig_wu.im_stack,
+    #     config=orig_wu.config,
+    #     per_image_wcs=orig_wu._per_image_wcs,
+    #     per_image_ebd_wcs=ebd_per_image_wcs,
+    #     heliocentric_distance=guess_dist,#args.guess_dist,
+    #     geocentric_distances=geocentric_dists,
+    # )
+    # elapsed = round(time.time() - last_time, 1)
+    # print_debug(f"{elapsed} seconds elapsed to create EBD WorkUnit.")
+
+    # del orig_wu # 6/7/2024 COC
+
+    # # Reproject to a common WCS using the WCS for our patch
+    # print_debug(f"Reprojecting WorkUnit with {n_workers} workers...")
+    # last_time = time.time()
+    # reprojected_wu = reprojection.reproject_work_unit(ebd_wu, patch_wcs, frame="ebd", max_parallel_processes=n_workers)
+    # elapsed = round(time.time() - last_time, 1)
+    # print_debug(f"{elapsed} seconds elapsed to create the reprojected WorkUnit.")
+    # #   print_debug("Reprojected WorkUnit created")
+
+    # # Save the reprojected WorkUnit
+    # reprojected_wu_file = os.path.join(args.result_dir, "reprojected_wu.fits")
+    # print_debug(f"Saving reprojected work unit to: {reprojected_wu_file}")
+    # last_time = time.time()
+    # reprojected_wu.to_fits(reprojected_wu_file)
+    # elapsed = round(time.time() - last_time, 1)
+    # print_debug(f"{elapsed} seconds elapsed to create the reprojected WorkUnit: {reprojected_wu_file}")
+
+    # def _get_params_from_uri_file(self, uri_file):
+    #     """
+    #     Get parameters we place into URI file as comments at the top.
+    #     Example start of URI file (6/6/2024 COC):
+    #     #desired_dates=['2019-04-02', '2019-05-07']
+    #     #dist_au=42.0
+    #     #patch_size=[20, 20]
+    #     #patch_id=5845
+    #     #patch_center_coords=(216.49999999999997, -13.500000000000005)
+    #     #patch_box=[[216.33333333333331, -13.666666666666671], [216.33333333333331, -13.333333333333337], [216.66666666666666, -13.333333333333337], [216.66666666666666, -13.666666666666671], [216.33333333333331, -13.666666666666671]]
+    #     /gscratch/dirac/DEEP/repo/DEEP/20190507/A0b/science#step6/20240425T145342Z/differenceExp/20190508/VR/VR_DECam_c0007_6300.0_2600.0/855719/differenceExp_DECam_VR_VR_DECam_c0007_6300_0_2600_0_855719_S12_DEEP_20190507_A0b_scienceHASHstep6_20240425T145342Z.fits
+    #     6/6/2024 COC
+    #     """
+    #     results = {}
+    #     with open(uri_file, 'r') as f:
+    #         for line in f:
+    #             line = line.strip()
+    #             if line == '': continue # deal with rogue blank lines or invisible double line endings
+    #             if not line.startswith('#'): break # comments section is done
+    #             line = line.lstrip('#').split('=')
+    #             lhs = line[0].strip()
+    #             rhs = line[1].strip()
+    #             try:
+    #                 rhs = eval(rhs)
+    #             except ValueError:
+    #                 self.logger.debug(f'Unable to eval() {lhs} field with value {rhs}.')
+    #                 continue
+    #             results[lhs] = rhs
+    #     return results
+
+    # def _patch_arcmin_to_pixels(self, patch_size_arcmin, pixel_scale_arcsec_per_pix):
+    #     """
+    #     Take an array of two dimensions, in arcminutes, and convert this to pixels using the supplied pixel scale (in arcseconds per pixel).
+    #     6/6/2024 COC
+    #     """
+    #     x_pixels = int(np.ceil( (patch_size_arcmin[0]*60)/pixel_scale_arcsec_per_pix ))
+    #     y_pixels = int(np.ceil( (patch_size_arcmin[1]*60)/pixel_scale_arcsec_per_pix ))
+
+    #     patch_pixels = int( np.ceil( patch_size_arcmin * 60 / pixel_scale_arcsec_per_pix ) )
+    #     patch_pixels = [ x_pixels, y_pixels ]
+
+    #     self.logger.debug(
+    #         f"Derived patch_pixels = {patch_pixels} from patch_size_arcmin={patch_size_arcmin} and pixel_scale_arcsec_per_pix={pixel_scale_arcsec_per_pix}."
+    #     )
+
+    #     return x_pixels, y_pixels
+
+    # def _create_wcs_from_corners(self, corners=None, image_width=None, image_height=None, save_fits=False, filename='output.fits', pixel_scale=None, verbose=True):
+    #     """
+    #     Create a WCS object given the RA, Dec coordinates of the four corners of the image
+    #     and the dimensions of the image in pixels. Optionally save as a FITS file.
+
+    #     Parameters:
+    #     corners (list of lists): [[RA1, Dec1], [RA2, Dec2], [RA3, Dec3], [RA4, Dec4]]
+    #     image_width (int): Width of the image in pixels; if none, pixel_scale will be used to determine size.
+    #     image_height (int): Height of the image in pixels; if none, pixel_scale will be used to determine size.
+    #     save_fits (bool): If True, save the WCS to a FITS file
+    #     filename (str): The name of the FITS file to save
+    #     pixel_scale (float): The pixel scale (in units of arcseconds per pixel); used if image_width or image_height is None.
+    #     verbose (bool): Print more messages.
+
+    #     Returns:
+    #     WCS: The World Coordinate System object for the image
+
+    #     5/6/2024 COC + ChatGPT4
+    #     """
+    #     # TODO switch to https://docs.astropy.org/en/stable/api/astropy.wcs.utils.fit_wcs_from_points.html
+    #     # Extract the corners
+    #     if verbose: print_debug(f'At the start, corners={corners}, type={type(corners)}')
+    #     if type(corners) == type((0,1)) or len(corners) == 1:
+    #         corners = corners[0]
+    #         print_debug(f'After un-tuple corners are {corners}.')
+    #     corners = np.unique(corners, axis=0) # eliminate duplicate coords in case someone passes the repeat 1st corner used for plotting 6/5/2024 COC/DO
+    #     if len(corners) != 4:
+    #         raise ValueError(f'There should be four (4) corners. We saw: {corners}')
+    #     ra = [corner[0] for corner in corners]
+    #     dec = [corner[1] for corner in corners]
+    #     #
+    #     # Calculate the central position (average of the coordinates)
+    #     center_ra = np.mean(ra)
+    #     center_dec = np.mean(dec)
+    #     #
+    #     # Calculate the pixel scale in degrees per pixel
+    #     if pixel_scale is not None:
+    #         pixel_scale_ra = pixel_scale/60/60
+    #         pixel_scale_dec = pixel_scale/60/60
+    #     else:
+    #         ra_range = (max(ra) - min(ra)) # * np.cos(np.radians(center_dec))  # Adjust RA difference for declination; do not use cos(), results in incorrect pixel scale 6/6/2024 COC
+    #         dec_range = max(dec) - min(dec)
+    #         pixel_scale_ra = ra_range / image_width
+    #         pixel_scale_dec = dec_range / image_height
+    #     if verbose: print_debug(f'Saw (RA,Dec) pixel scales ({pixel_scale_ra*60*60},{pixel_scale_dec*60*60})"/pixel. User-supplied: {pixel_scale}"/pixel.')
+    #     # Initialize a WCS object with 2 axes (RA and Dec)
+    #     wcs = WCS(naxis=2)
+    #     wcs.wcs.crpix = [image_width / 2, image_height / 2]
+    #     wcs.wcs.crval = [center_ra, center_dec]
+    #     wcs.wcs.cdelt = [-pixel_scale_ra, pixel_scale_dec]  # RA pixel scale might need to be negative (convention)
+    #     # Rotation matrix, assuming no rotation
+    #     wcs.wcs.pc = [[1, 0], [0, 1]]
+    #     # Define coordinate frame and projection
+    #     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    #     wcs.array_shape = (image_height, image_width)
+    #     if save_fits:
+    #         # Create a new FITS file with the WCS information and a dummy data array
+    #         hdu = fits.PrimaryHDU(data=np.ones((image_height, image_width)), header=wcs.to_header())
+    #         hdulist = fits.HDUList([hdu])
+    #         hdulist.writeto(filename, overwrite=True)
+    #         print_debug(f"Saved FITS file with WCS to {filename}")
+    #     return wcs
+
+    def create_work_unit(self):
+        make_wu = True
+        if len(glob.glob(self.wu_file)):
+            if self.overwrite:
+                self.logger.debug(f"Overwrite was {self.overwrite}. Deleting existing {self.wu_file}.")
+                os.remove(self.wu_file)
+            else:
+                make_wu = False
+
+        if make_wu:
+            ic = ImageCollection.read(self.ic_input_file, format="ascii.ecsv")
+            self.logger.debug(f"ImageCollection read from {self.ic_input_file}, creating work unit next.")
+
+            last_time = time.time()
+            orig_wu = ic.toWorkUnit(
+                config=kbmod.configuration.SearchConfiguration.from_file(self.search_config)
+            )
+            elapsed = round(time.time() - last_time, 1)
+            self.logger.info(f"{elapsed} seconds to create WorkUnit.")
+
+            last_time = time.time()
+            orig_wu.to_fits(self.wu_file, overwrite=True)
+            elapsed = round(time.time() - last_time, 1)
+            self.logger.info(f"Saving original work unit to: {self.wu_file}")
+            self.logger.info(f"{elapsed} seconds to write WorkUnit to disk: {self.wu_file}")
+
+        return self.wu_file

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -3,6 +3,7 @@ from kbmod.work_unit import WorkUnit
 
 import os
 import time
+from logging import Logger
 
 
 def placeholder_kbmod_search(input_wu=None, result_file=None, logger=None):
@@ -21,13 +22,17 @@ def placeholder_kbmod_search(input_wu=None, result_file=None, logger=None):
 
 
 def kbmod_search(
-    input_wu=None, search_config_filepath=None, runtime_config={}, result_file=None, logger=None
+    wu_filepath: str = None,
+    search_config_filepath: str = None,  # ! Seems like this should be provided in the runtime_config dictionary ???
+    result_filepath: str = None,
+    runtime_config: dict = {},
+    logger: Logger = None,
 ):
     kbmod_searcher = KBMODSearcher(
-        input_wu_filepath=input_wu,
+        wu_filepath=wu_filepath,
         search_config_filepath=search_config_filepath,
+        result_filepath=result_filepath,
         runtime_config=runtime_config,
-        output_filepath=result_file,
         logger=logger,
     )
 
@@ -35,11 +40,18 @@ def kbmod_search(
 
 
 class KBMODSearcher:
-    def __init__(self, input_wu_filepath, search_config_filepath, runtime_config, output_filepath, logger):
-        self.input_wu_filepath = input_wu_filepath
+    def __init__(
+        self,
+        wu_filepath: str = None,
+        search_config_filepath: str = None,
+        result_filepath: str = None,
+        runtime_config: dict = {},
+        logger: Logger = None,
+    ):
+        self.input_wu_filepath = wu_filepath
         self.search_config_filepath = search_config_filepath
         self.runtime_config = runtime_config
-        self.output_filepath = output_filepath
+        self.output_filepath = result_filepath
         self.logger = logger
 
     def run_search(self):
@@ -68,9 +80,9 @@ class KBMODSearcher:
         res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
 
         self.logger.info("Search complete")
-        self.logger.info(f"Search results: {res}")
+        self.logger.info(f"Search results: {res}")  # ! Should this be logged to a file ???
 
-        self.logger.info("writing results table")
+        self.logger.info(f"Writing results to output file: {self.output_filepath}")
         res.write_table(self.output_filepath)
 
         return self.output_filepath

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -1,7 +1,11 @@
+import kbmod
+from kbmod.work_unit import WorkUnit
+
+import os
 import time
 
 
-def kbmod_search(input_wu=None, result_file=None, logger=None):
+def placeholder_kbmod_search(input_wu=None, result_file=None, logger=None):
     logger.info("In the kbmod_search task_impl")
     with open(input_wu, "r") as f:
         for line in f:
@@ -14,3 +18,59 @@ def kbmod_search(input_wu=None, result_file=None, logger=None):
         f.write(f"Logged: {value} - {time.time()}\n")
 
     return result_file
+
+
+def kbmod_search(
+    input_wu=None, search_config_filepath=None, runtime_config={}, result_file=None, logger=None
+):
+    kbmod_searcher = KBMODSearcher(
+        input_wu_filepath=input_wu,
+        search_config_filepath=search_config_filepath,
+        runtime_config=runtime_config,
+        output_filepath=result_file,
+        logger=logger,
+    )
+
+    return kbmod_searcher.run_search()
+
+
+class KBMODSearcher:
+    def __init__(self, input_wu_filepath, search_config_filepath, runtime_config, output_filepath, logger):
+        self.input_wu_filepath = input_wu_filepath
+        self.search_config_filepath = search_config_filepath
+        self.runtime_config = runtime_config
+        self.output_filepath = output_filepath
+        self.logger = logger
+
+    def run_search(self):
+        self.logger.info("Loading workunit from file")
+        wu = WorkUnit.from_fits(self.input_wu_filepath)
+
+        self.logger.debug("Loaded work unit")
+        if self.search_config is not None:
+            # Load a search configuration, otherwise use the one loaded with the work unit
+            wu.config = kbmod.configuration.SearchConfiguration.from_file(self.search_config)
+
+        config = wu.config
+
+        # Modify the work unit results to be what is specified in command line args
+        input_parameters = {
+            "res_filepath": args.result_dir,
+            "result_filename": os.path.join(args.result_dir, "full_results.ecsv"),
+        }
+        config.set_multiple(input_parameters)
+
+        # Save the search config in the results directory for record keeping
+        config.to_file(os.path.join(args.result_dir, "search_config.yaml"))
+        wu.config = config
+
+        self.logger.info("Running KBMOD search")
+        res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
+
+        self.logger.info("Search complete")
+        self.logger.info(f"Search results: {res}")
+
+        self.logger.info("writing results table")
+        res.write_table(self.output_filepath)
+
+        return self.output_filepath

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -23,14 +23,28 @@ def placeholder_kbmod_search(input_wu=None, result_file=None, logger=None):
 
 def kbmod_search(
     wu_filepath: str = None,
-    search_config_filepath: str = None,  # ! Seems like this should be provided in the runtime_config dictionary ???
     result_filepath: str = None,
     runtime_config: dict = {},
     logger: Logger = None,
 ):
+    """This task will run the KBMOD search algorithm on a WorkUnit.
+
+    Parameters
+    ----------
+    wu_filepath : str, optional
+        The fully resolved filepath to the input WorkUnit file, by default None
+    runtime_config : dict, optional
+        Additional configuration parameters to be used at runtime, by default {}
+    logger : Logger, optional
+        Primary logger for the workflow, by default None
+
+    Returns
+    -------
+    str
+        The fully resolved filepath of the results file.
+    """
     kbmod_searcher = KBMODSearcher(
         wu_filepath=wu_filepath,
-        search_config_filepath=search_config_filepath,
         result_filepath=result_filepath,
         runtime_config=runtime_config,
         logger=logger,
@@ -43,46 +57,47 @@ class KBMODSearcher:
     def __init__(
         self,
         wu_filepath: str = None,
-        search_config_filepath: str = None,
         result_filepath: str = None,
         runtime_config: dict = {},
         logger: Logger = None,
     ):
         self.input_wu_filepath = wu_filepath
-        self.search_config_filepath = search_config_filepath
         self.runtime_config = runtime_config
-        self.output_filepath = result_filepath
+        self.result_filepath = result_filepath
         self.logger = logger
+
+        self.search_config_filepath = self.runtime_config.get("search_config_filepath", None)
+        self.results_directory = os.path.dirname(self.result_filepath)
 
     def run_search(self):
         self.logger.info("Loading workunit from file")
         wu = WorkUnit.from_fits(self.input_wu_filepath)
 
         self.logger.debug("Loaded work unit")
-        if self.search_config is not None:
+        if self.search_config_filepath is not None:
             # Load a search configuration, otherwise use the one loaded with the work unit
-            wu.config = kbmod.configuration.SearchConfiguration.from_file(self.search_config)
+            wu.config = kbmod.configuration.SearchConfiguration.from_file(self.search_config_filepath)
 
         config = wu.config
 
         # Modify the work unit results to be what is specified in command line args
         input_parameters = {
-            "res_filepath": args.result_dir,
-            "result_filename": os.path.join(args.result_dir, "full_results.ecsv"),
+            "res_filepath": self.results_directory,
+            "result_filename": self.result_filepath,
         }
         config.set_multiple(input_parameters)
 
         # Save the search config in the results directory for record keeping
-        config.to_file(os.path.join(args.result_dir, "search_config.yaml"))
+        config.to_file(os.path.join(self.results_directory, "search_config.yaml"))
         wu.config = config
 
         self.logger.info("Running KBMOD search")
         res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
 
         self.logger.info("Search complete")
-        self.logger.info(f"Search results: {res}")  # ! Should this be logged to a file ???
+        self.logger.info(f"Number of results found: {len(res)}")
 
-        self.logger.info(f"Writing results to output file: {self.output_filepath}")
-        res.write_table(self.output_filepath)
+        self.logger.info(f"Writing results to output file: {self.result_filepath}")
+        res.write_table(self.result_filepath)
 
-        return self.output_filepath
+        return self.result_filepath

--- a/src/kbmod_wf/task_impls/reproject_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_wu.py
@@ -1,7 +1,17 @@
+from kbmod.work_unit import WorkUnit
+from kbmod.reprojection_utils import transform_wcses_to_ebd
+
+import kbmod.reprojection as reprojection
+from astropy.wcs import WCS
+from astropy.io import fits
+from astropy.coordinates import EarthLocation
+import astropy.time
+import numpy as np
+import os
 import time
 
 
-def reproject_wu(input_wu=None, reprojected_wu=None, logger=None):
+def placeholder_reproject_wu(input_wu=None, reprojected_wu=None, logger=None):
     logger.info("In the reproject_wu task_impl")
     with open(input_wu, "r") as f:
         for line in f:
@@ -12,3 +22,279 @@ def reproject_wu(input_wu=None, reprojected_wu=None, logger=None):
         f.write(f"Logged: {value} - {time.time()}\n")
 
     return reprojected_wu
+
+
+def reproject_wu(original_wu=None, uri_file=None, runtime_config={}, reprojected_wu=None, logger=None):
+    wu_reprojector = WUReprojector(
+        original_wu=original_wu,
+        uri_file=uri_file,
+        runtime_config=runtime_config,
+        reprojected_wu=reprojected_wu,
+        logger=logger,
+    )
+
+    return wu_reprojector.reproject_workunit()
+
+
+class WUReprojector:
+    def __init__(
+        self,
+        original_wu_filepath=None,
+        uri_filepath=None,
+        runtime_config={},
+        reprojected_wu_filepath=None,
+        logger=None,
+    ):
+        self.original_wu_filepath = original_wu_filepath
+        self.uri_filepath = uri_filepath
+        self.runtime_config = runtime_config
+        self.reprojected_wu_filepath = reprojected_wu_filepath
+        self.logger = logger
+
+        self.overwrite = self.runtime_config.get("overwrite", False)
+        self.search_config = self.runtime_config.get("search_config", None)
+
+        # Default to 8 workers if not in the config. Value must be 0<num workers<65.
+        self.n_workers = np.max(1, np.min(self.runtime_config.get("n_workers", 8), 64))
+
+        # ! Decide if we want these from a runtime_config or exclusively read from the uri file
+        self.patch_corners = self.runtime_config.get("patch_corners", None)
+        self.guess_dist = self.runtime_config.get("guess_dist", None)
+        self.pixel_scale = self.runtime_config.get("pixel_scale", None)
+
+        # ! Decide if we want these from a runtime_config or calculate each time based on self.uri_params
+        self.image_width = self.runtime_config.get("image_width", None)
+        self.image_height = self.runtime_config.get("image_height", None)
+
+        self.uri_params = self._get_params_from_uri_file(uri_file=self.uri_file)
+
+        self.pixel_scale = self.uri_params["pixel_scale"]
+        self.patch_size = self.uri_params["patch_size"]
+
+        # handle image dimensions
+        if self.image_width == None or self.image_height == None:
+            if "patch_size" not in self.uri_params:
+                raise KeyError(
+                    f"Must supply image dimensions (image_width, image_height) or #patch_size= must be in a specified URI file."
+                )
+            if self.pixel_scale == None:
+                raise KeyError(
+                    f"When patch pixel dimensions are not specifified, the user must supply a pixel scale via the command line or the uri file."
+                )
+
+        self.image_width, self.image_height = self._patch_arcmin_to_pixels(
+            patch_size_arcmin=self.patch_size,
+            pixel_scale_arcsec_per_pix=self.pixel_scale,
+        )
+
+        self.point_on_earth = EarthLocation(1814303.74553723, -5214365.7436216, -3187340.56598756, unit="m")
+
+    def reproject_workunit(self):
+        self.logger.debug(f"Creating WCS from patch")
+
+        # Create a WCS object for the patch. This will be our common reprojection WCS
+        patch_fits_name = f"patch.fits"
+        if "patch_id" in self.uri_params:
+            patch_fits_name = f"patch_{self.uri_params['patch_id']}.fits"
+
+        # ! TODO: Need to figure out what to do with args.result_dir here. Pass `filename` as an parsl.output?
+        patch_wcs = self._create_wcs_from_corners(
+            self.patch_corners,
+            self.image_width,
+            self.image_height,
+            pixel_scale=self.pixel_scale,
+            filename=os.path.join(args.result_dir, patch_fits_name),
+        )
+
+        self.logger.info(f"Reading existing WorkUnit from disk: {self.original_wu_filepath}")
+        orig_wu = WorkUnit.from_fits(self.original_wu_filepath)
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"{elapsed} seconds to read original WorkUnit ({self.original_wu_filepath}).")
+
+        # gather elements needed for reproject phase
+        imgs = orig_wu.im_stack
+
+        # Find the EBD (estimated barycentric distance) WCS for each image
+        last_time = time.time()
+        ebd_per_image_wcs, geocentric_dists = transform_wcses_to_ebd(
+            orig_wu._per_image_wcs,
+            imgs.get_single_image(0).get_width(),
+            imgs.get_single_image(0).get_height(),
+            self.guess_dist,
+            [astropy.time.Time(img.get_obstime(), format="mjd") for img in imgs.get_images()],
+            self.point_on_earth,
+            npoints=10,
+            seed=None,
+        )
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"{elapsed} seconds elapsed for transform WCS objects to EBD phase.")
+
+        if len(orig_wu._per_image_wcs) != len(ebd_per_image_wcs):
+            raise ValueError(
+                f"Number of barycentric WCS objects ({len(ebd_per_image_wcs)}) does not match the original number of images ({len(orig_wu._per_image_wcs)})."
+            )
+
+        # Construct a WorkUnit with the EBD WCS and provenance data
+        self.logger.debug(f"Creating Barycentric WorkUnit...")
+        last_time = time.time()
+        ebd_wu = WorkUnit(
+            im_stack=orig_wu.im_stack,
+            config=orig_wu.config,
+            per_image_wcs=orig_wu._per_image_wcs,
+            per_image_ebd_wcs=ebd_per_image_wcs,
+            heliocentric_distance=self.guess_dist,
+            geocentric_distances=geocentric_dists,
+        )
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"{elapsed} seconds elapsed to create EBD WorkUnit.")
+
+        # Reproject to a common WCS using the WCS for our patch
+        self.logger.debug(f"Reprojecting WorkUnit with {self.n_workers} workers...")
+        last_time = time.time()
+        reprojected_wu = reprojection.reproject_work_unit(
+            ebd_wu, patch_wcs, frame="ebd", max_parallel_processes=self.n_workers
+        )
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"{elapsed} seconds elapsed to create the reprojected WorkUnit.")
+
+        # Save the reprojected WorkUnit
+        self.logger.debug(f"Saving reprojected work unit to: {self.reprojected_wu_filepath}")
+        last_time = time.time()
+        reprojected_wu.to_fits(self.reprojected_wu_filepath)
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(
+            f"{elapsed} seconds elapsed to create the reprojected WorkUnit: {self.reprojected_wu_filepath}"
+        )
+
+        return self.reprojected_wu_filepath
+
+    def _get_params_from_uri_file(self, uri_file):
+        """
+        Get parameters we place into URI file as comments at the top.
+        Example start of URI file (6/6/2024 COC):
+        #desired_dates=['2019-04-02', '2019-05-07']
+        #dist_au=42.0
+        #patch_size=[20, 20]
+        #patch_id=5845
+        #patch_center_coords=(216.49999999999997, -13.500000000000005)
+        #patch_box=[[216.33333333333331, -13.666666666666671], [216.33333333333331, -13.333333333333337], [216.66666666666666, -13.333333333333337], [216.66666666666666, -13.666666666666671], [216.33333333333331, -13.666666666666671]]
+        /gscratch/dirac/DEEP/repo/DEEP/20190507/A0b/science#step6/20240425T145342Z/differenceExp/20190508/VR/VR_DECam_c0007_6300.0_2600.0/855719/differenceExp_DECam_VR_VR_DECam_c0007_6300_0_2600_0_855719_S12_DEEP_20190507_A0b_scienceHASHstep6_20240425T145342Z.fits
+        6/6/2024 COC
+        """
+        results = {}
+        with open(uri_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line == "":
+                    continue  # deal with rogue blank lines or invisible double line endings
+                if not line.startswith("#"):
+                    break  # comments section is done
+                line = line.lstrip("#").split("=")
+                lhs = line[0].strip()
+                rhs = line[1].strip()
+                try:
+                    rhs = eval(rhs)
+                except ValueError:
+                    self.logger.debug(f"Unable to eval() {lhs} field with value {rhs}.")
+                    continue
+                results[lhs] = rhs
+        return results
+
+    def _patch_arcmin_to_pixels(self, patch_size_arcmin, pixel_scale_arcsec_per_pix):
+        """
+        Take an array of two dimensions, in arcminutes, and convert this to pixels using the supplied pixel scale (in arcseconds per pixel).
+        6/6/2024 COC
+        """
+        x_pixels = int(np.ceil((patch_size_arcmin[0] * 60) / pixel_scale_arcsec_per_pix))
+        y_pixels = int(np.ceil((patch_size_arcmin[1] * 60) / pixel_scale_arcsec_per_pix))
+
+        patch_pixels = int(np.ceil(patch_size_arcmin * 60 / pixel_scale_arcsec_per_pix))
+        patch_pixels = [x_pixels, y_pixels]
+
+        self.logger.debug(
+            f"Derived patch_pixels (w, h) = {patch_pixels} from patch_size_arcmin={patch_size_arcmin} and pixel_scale_arcsec_per_pix={pixel_scale_arcsec_per_pix}."
+        )
+
+        return x_pixels, y_pixels
+
+    def _create_wcs_from_corners(
+        self,
+        corners=None,
+        image_width=None,
+        image_height=None,
+        filename="output.fits",
+        pixel_scale=None,
+        verbose=True,
+    ):
+        """
+        Create a WCS object given the RA, Dec coordinates of the four corners of the image
+        and the dimensions of the image in pixels. Optionally save as a FITS file.
+
+        Parameters:
+        corners (list of lists): [[RA1, Dec1], [RA2, Dec2], [RA3, Dec3], [RA4, Dec4]]
+        image_width (int): Width of the image in pixels; if none, pixel_scale will be used to determine size.
+        image_height (int): Height of the image in pixels; if none, pixel_scale will be used to determine size.
+        filename (str): The name of the FITS file to save
+        pixel_scale (float): The pixel scale (in units of arcseconds per pixel); used if image_width or image_height is None.
+        verbose (bool): Print more messages.
+
+        Returns:
+        WCS: The World Coordinate System object for the image
+
+        5/6/2024 COC + ChatGPT4
+        """
+        # TODO switch to https://docs.astropy.org/en/stable/api/astropy.wcs.utils.fit_wcs_from_points.html
+        # Extract the corners
+        if verbose:
+            self.logger.debug(f"At the start, corners={corners}, type={type(corners)}")
+        if type(corners) == type((0, 1)) or len(corners) == 1:
+            corners = corners[0]
+            self.logger.debug(f"After un-tuple corners are {corners}.")
+        corners = np.unique(
+            corners, axis=0
+        )  # eliminate duplicate coords in case someone passes the repeat 1st corner used for plotting 6/5/2024 COC/DO
+        if len(corners) != 4:
+            raise ValueError(f"There should be four (4) corners. We saw: {corners}")
+        ra = [corner[0] for corner in corners]
+        dec = [corner[1] for corner in corners]
+        #
+        # Calculate the central position (average of the coordinates)
+        center_ra = np.mean(ra)
+        center_dec = np.mean(dec)
+        #
+        # Calculate the pixel scale in degrees per pixel
+        if pixel_scale is not None:
+            pixel_scale_ra = pixel_scale / 60 / 60
+            pixel_scale_dec = pixel_scale / 60 / 60
+        else:
+            ra_range = max(ra) - min(
+                ra
+            )  # * np.cos(np.radians(center_dec))  # Adjust RA difference for declination; do not use cos(), results in incorrect pixel scale 6/6/2024 COC
+            dec_range = max(dec) - min(dec)
+            pixel_scale_ra = ra_range / image_width
+            pixel_scale_dec = dec_range / image_height
+        if verbose:
+            self.logger.debug(
+                f'Saw (RA,Dec) pixel scales ({pixel_scale_ra*60*60},{pixel_scale_dec*60*60})"/pixel. User-supplied: {pixel_scale}"/pixel.'
+            )
+        # Initialize a WCS object with 2 axes (RA and Dec)
+        wcs = WCS(naxis=2)
+        wcs.wcs.crpix = [image_width / 2, image_height / 2]
+        wcs.wcs.crval = [center_ra, center_dec]
+        wcs.wcs.cdelt = [
+            -pixel_scale_ra,
+            pixel_scale_dec,
+        ]  # RA pixel scale might need to be negative (convention)
+        # Rotation matrix, assuming no rotation
+        wcs.wcs.pc = [[1, 0], [0, 1]]
+        # Define coordinate frame and projection
+        wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+        wcs.array_shape = (image_height, image_width)
+
+        # Create a new FITS file with the WCS information and a dummy data array
+        hdu = fits.PrimaryHDU(data=np.ones((image_height, image_width)), header=wcs.to_header())
+        hdulist = fits.HDUList([hdu])
+        hdulist.writeto(filename, overwrite=True)
+        self.logger.debug(f"Saved FITS file with WCS to {filename}")
+
+        return wcs

--- a/src/kbmod_wf/task_impls/uri_to_ic.py
+++ b/src/kbmod_wf/task_impls/uri_to_ic.py
@@ -1,11 +1,13 @@
 import os
 import glob
 import time
+from logging import Logger
+from kbmod import ImageCollection
 
-# from kbmod import ImageCollection
 
-
-def uri_to_ic(target_uris_file_path=None, uris_base_dir=None, ic_output_file_path=None, logger=None):
+def placeholder_uri_to_ic(
+    target_uris_file_path=None, uris_base_dir=None, ic_output_file_path=None, logger=None
+):
     with open(target_uris_file_path, "r") as f:
         for line in f:
             value = line.strip()
@@ -19,21 +21,29 @@ def uri_to_ic(target_uris_file_path=None, uris_base_dir=None, ic_output_file_pat
 
 #! I believe that we can remove the `uris_base_dir` parameter from the function
 #! signature. It doesn't seem to be used in practice.
-def no_uri_to_ic(target_uris_file_path=None, uris_base_dir=None, ic_output_file_path=None, logger=None):
+def uri_to_ic(
+    uris_filepath: str = None,
+    uris_base_dir: str = None,
+    ic_filepath: str = None,
+    runtime_config: dict = {},
+    logger: Logger = None,
+):
     """For each URI in the target_uris_file, perform string cleaning and build a
     file path. Then create an ImageCollection object with the final file paths
     and write the ImageCollection to a file.
 
     Parameters
     ----------
-    target_uris_file_path : str, optional
-        The fully resolved path to the file containing the list of URIs, by default None
+    uris_filepath : str, optional
+        The fully resolved path to the input file containing the list of URIs, by default None
     uris_base_dir : str, optional
         The directory containing the files references by URI in the target_uris_file,
         by default None
-    ic_output_file_path : _type_, optional
+    ic_filepath : str, optional
         The fully resolved path to the output file where the ImageCollection will
         be saved, by default None
+    runtime_config : dict, optional
+        Any parameters that must be set for this work to be performed, by default {}
     logger : Logger, optional
         The logger to use for this work, by default None
 
@@ -48,7 +58,7 @@ def no_uri_to_ic(target_uris_file_path=None, uris_base_dir=None, ic_output_file_
 
     # Load the list of images from our saved file "sample_uris.txt"
     uris = []
-    with open(target_uris_file_path) as f:
+    with open(uris_filepath) as f:
         for l in f.readlines():
             l = l.strip()  # seeing invisible trailing characters 6/12/2024 COC
             if l == "":
@@ -86,7 +96,7 @@ def no_uri_to_ic(target_uris_file_path=None, uris_base_dir=None, ic_output_file_
 
     logger.info("Creating ImageCollection")
     # Create an ImageCollection object from the list of URIs
-    # ic = ImageCollection.fromTargets(uris)
+    ic = ImageCollection.fromTargets(uris)
 
-    logger.info(f"Writing ImageCollection to file {ic_output_file_path}")
-    # ic.write(ic_output_file_path, format="ascii.ecsv")
+    logger.info(f"Writing ImageCollection to file {ic_filepath}")
+    ic.write(ic_filepath, format="ascii.ecsv")

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -127,7 +127,6 @@ def kbmod_search(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     logger.info("Starting kbmod_search")
     kbmod_search(
         wu_filepath=inputs[0].filepath,
-        search_config_filepath=None,  # ! determine what, if any, value should be used.
         result_filepath=outputs[0].filepath,
         runtime_config=runtime_config,
         logger=logger,

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -53,27 +53,7 @@ def create_uri_manifest(inputs=[], outputs=[], config={}, logging_file=None):
 @python_app(
     cache=True, executors=get_executors(["local_dev_testing", "small_cpu"]), ignore_for_cache=["logging_file"]
 )
-def read_and_log(inputs=[], outputs=[], logging_file=None):
-    """THIS IS A PLACEHOLDER FUNCTION THAT WILL BE REMOVED SOON"""
-    from kbmod_wf.utilities.logger_utilities import configure_logger
-
-    logger = configure_logger("task.read_and_log", logging_file.filepath)
-
-    with open(inputs[0].filepath, "r") as f:
-        for line in f:
-            value = line.strip()
-            logger.info(line.strip())
-
-    with open(outputs[0].filepath, "w") as f:
-        f.write(f"Logged: {value}")
-
-    return outputs[0]
-
-
-@python_app(
-    cache=True, executors=get_executors(["local_dev_testing", "small_cpu"]), ignore_for_cache=["logging_file"]
-)
-def uri_to_ic(inputs=[], outputs=[], logging_file=None):
+def uri_to_ic(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import configure_logger
     from kbmod_wf.task_impls.uri_to_ic import uri_to_ic
 
@@ -81,9 +61,10 @@ def uri_to_ic(inputs=[], outputs=[], logging_file=None):
 
     logger.info("Starting uri_to_ic")
     uri_to_ic(
-        target_uris_file_path=inputs[0].filepath,
+        uris_filepath=inputs[0].filepath,
         uris_base_dir=None,  # determine what, if any, value should be used.
-        ic_output_file_path=outputs[0].filepath,
+        ic_filepath=outputs[0].filepath,
+        runtime_config=runtime_config,
         logger=logger,
     )
     logger.warning("Completed uri_to_ic")
@@ -94,14 +75,19 @@ def uri_to_ic(inputs=[], outputs=[], logging_file=None):
 @python_app(
     cache=True, executors=get_executors(["local_dev_testing", "small_cpu"]), ignore_for_cache=["logging_file"]
 )
-def ic_to_wu(inputs=[], outputs=[], logging_file=None):
+def ic_to_wu(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import configure_logger
     from kbmod_wf.task_impls.ic_to_wu import ic_to_wu
 
     logger = configure_logger("task.ic_to_wu", logging_file.filepath)
 
     logger.info("Starting ic_to_wu")
-    ic_to_wu(ic_file=inputs[0].filepath, wu_file=outputs[0].filepath, logger=logger)
+    ic_to_wu(
+        ic_filepath=inputs[0].filepath,
+        wu_filepath=outputs[0].filepath,
+        runtime_config=runtime_config,
+        logger=logger,
+    )
     logger.warning("Completed ic_to_wu")
 
     return outputs[0]
@@ -110,14 +96,20 @@ def ic_to_wu(inputs=[], outputs=[], logging_file=None):
 @python_app(
     cache=True, executors=get_executors(["local_dev_testing", "small_cpu"]), ignore_for_cache=["logging_file"]
 )
-def reproject_wu(inputs=[], outputs=[], logging_file=None):
+def reproject_wu(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import configure_logger
     from kbmod_wf.task_impls.reproject_wu import reproject_wu
 
     logger = configure_logger("task.reproject_wu", logging_file.filepath)
 
     logger.info("Starting reproject_ic")
-    reproject_wu(input_wu=inputs[0].filepath, reprojected_wu=outputs[0].filepath, logger=logger)
+    reproject_wu(
+        original_wu_filepath=inputs[0].filepath,
+        uri_filepath=None,  # ! determine what, if any, value should be used.
+        reprojected_wu_filepath=outputs[0].filepath,
+        runtime_config=runtime_config,
+        logger=logger,
+    )
     logger.warning("Completed reproject_ic")
 
     return outputs[0]
@@ -126,14 +118,20 @@ def reproject_wu(inputs=[], outputs=[], logging_file=None):
 @python_app(
     cache=True, executors=get_executors(["local_dev_testing", "small_cpu"]), ignore_for_cache=["logging_file"]
 )
-def kbmod_search(inputs=[], outputs=[], logging_file=None):
+def kbmod_search(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import configure_logger
     from kbmod_wf.task_impls.kbmod_search import kbmod_search
 
     logger = configure_logger("task.kbmod_search", logging_file.filepath)
 
     logger.info("Starting kbmod_search")
-    kbmod_search(input_wu=inputs[0].filepath, result_file=outputs[0].filepath, logger=logger)
+    kbmod_search(
+        wu_filepath=inputs[0].filepath,
+        search_config_filepath=None,  # ! determine what, if any, value should be used.
+        result_filepath=outputs[0].filepath,
+        runtime_config=runtime_config,
+        logger=logger,
+    )
     logger.warning("Completed kbmod_search")
 
     return outputs[0]


### PR DESCRIPTION
This PR is composed of several rough commits to pull over the code, including:
- Initial commit of ic_to_wu task. Copied script over, peeled away what was not needed.
- Pulling over the reprojection portion of the old `ic_to_wu` script.
- Included kbmod search script
- General clean up of function parameter names, and first pass over cleaning up the logging messages. 