### PR TITLE
Adding traceback to logging

### DIFF
--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -3,6 +3,7 @@ from kbmod.work_unit import WorkUnit
 
 import os
 import time
+import traceback
 from logging import Logger
 
 
@@ -92,8 +93,12 @@ class KBMODSearcher:
         wu.config = config
 
         self.logger.info("Running KBMOD search")
-        res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
-
+        try:
+            res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
+        except Exception as e:
+            self.logger.error(f"Error running KBMOD search: {e}")
+            self.logger.error(traceback.format_exc())
+            raise e
         self.logger.info("Search complete")
         self.logger.info(f"Number of results found: {len(res)}")
 

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -82,9 +82,11 @@ class KBMODSearcher:
         config = wu.config
 
         # Modify the work unit results to be what is specified in command line args
+        base_filename, _ = os.path.splitext(os.path.basename(self.result_filepath))
         input_parameters = {
             "res_filepath": self.results_directory,
             "result_filename": self.result_filepath,
+            "output_suffix": base_filename,
         }
         config.set_multiple(input_parameters)
 
@@ -93,12 +95,7 @@ class KBMODSearcher:
         wu.config = config
 
         self.logger.info("Running KBMOD search")
-        try:
-            res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
-        except Exception as e:
-            self.logger.error(f"Error running KBMOD search: {e}")
-            self.logger.error(traceback.format_exc())
-            raise e
+        res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
         self.logger.info("Search complete")
         self.logger.info(f"Number of results found: {len(res)}")
 

--- a/src/kbmod_wf/utilities/retry_utilities.py
+++ b/src/kbmod_wf/utilities/retry_utilities.py
@@ -1,0 +1,22 @@
+def klone_retry_handler(exception, task_record):
+    """Custom retry handler for Klone, that will not increment the retry count
+    when resources are preempted. I.e. if we lose access to resources, don't
+    count that as a failure, and don't increase the retry counter.
+
+    Parameters
+    ----------
+    exception : Exception
+        The exception that was raised during the task execution.
+    task_record : TaskRecord
+        The parsl TaskRecord for the task that failed.
+
+    Returns
+    -------
+    int
+        The amount by which to increment the retry counter.
+    """
+
+    if isinstance(exception, Exception):
+        return 0
+    else:
+        return 1

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -136,6 +136,7 @@ def kbmod_search(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     except Exception as e:
         logger.error(f"Error running kbmod_search: {e}")
         logger.error(traceback.format_exc())
+        raise e
     logger.warning("Completed kbmod_search")
 
     return outputs[0]
@@ -212,7 +213,7 @@ def workflow_runner(env: str = None, runtime_config: dict = {}) -> None:
             search_futures.append(
                 kbmod_search(
                     inputs=[f.result()],
-                    outputs=[File(f.result().filepath + ".search")],
+                    outputs=[File(f.result().filepath + ".search.ecsv")],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -119,18 +119,23 @@ def reproject_wu(inputs=[], outputs=[], runtime_config={}, logging_file=None):
     cache=True, executors=get_executors(["local_dev_testing", "gpu"]), ignore_for_cache=["logging_file"]
 )
 def kbmod_search(inputs=[], outputs=[], runtime_config={}, logging_file=None):
+    import traceback
     from kbmod_wf.utilities.logger_utilities import configure_logger
     from kbmod_wf.task_impls.kbmod_search import kbmod_search
 
     logger = configure_logger("task.kbmod_search", logging_file.filepath)
 
     logger.info("Starting kbmod_search")
-    kbmod_search(
-        wu_filepath=inputs[0].filepath,
-        result_filepath=outputs[0].filepath,
-        runtime_config=runtime_config,
-        logger=logger,
-    )
+    try:
+        kbmod_search(
+            wu_filepath=inputs[0].filepath,
+            result_filepath=outputs[0].filepath,
+            runtime_config=runtime_config,
+            logger=logger,
+        )
+    except Exception as e:
+        logger.error(f"Error running kbmod_search: {e}")
+        logger.error(traceback.format_exc())
     logger.warning("Completed kbmod_search")
 
     return outputs[0]


### PR DESCRIPTION
Goal here is to get a better sense of how to capture exceptions and log them to the main parsl.log file.