### PR TITLE
Pass kbmod logs up to parsl workflow level

### DIFF
--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -48,6 +48,7 @@ class ICtoWUConverter:
         self.wu_filepath = wu_filepath
         self.runtime_config = runtime_config
         self.logger = logger
+        kbmod._logging.basicConfig(level=self.logger.level)
 
         self.overwrite = self.runtime_config.get("overwrite", False)
         self.search_config_filepath = self.runtime_config.get("search_config_filepath", None)

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -49,6 +49,7 @@ class KBMODSearcher:
         self.runtime_config = runtime_config
         self.result_filepath = result_filepath
         self.logger = logger
+        kbmod._logging.basicConfig(level=self.logger.level)
 
         self.search_config_filepath = self.runtime_config.get("search_config_filepath", None)
         self.results_directory = os.path.dirname(self.result_filepath)

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -1,3 +1,4 @@
+import kbmod
 from kbmod.work_unit import WorkUnit
 from kbmod.reprojection_utils import transform_wcses_to_ebd
 
@@ -67,6 +68,7 @@ class WUReprojector:
         self.reprojected_wu_filepath = reprojected_wu_filepath
         self.runtime_config = runtime_config
         self.logger = logger
+        kbmod._logging.basicConfig(level=self.logger.level)
 
         self.overwrite = self.runtime_config.get("overwrite", False)
         self.search_config = self.runtime_config.get("search_config", None)

--- a/src/kbmod_wf/task_impls/reproject_single_chip_single_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_single_chip_single_night_wu.py
@@ -1,3 +1,4 @@
+import kbmod
 from kbmod.work_unit import WorkUnit
 
 import kbmod.reprojection as reprojection
@@ -56,6 +57,7 @@ class WUReprojector:
         self.reprojected_wu_filepath = reprojected_wu_filepath
         self.runtime_config = runtime_config
         self.logger = logger
+        kbmod._logging.basicConfig(level=self.logger.level)
 
         # Default to 8 workers if not in the config. Value must be 0<num workers<65.
         self.n_workers = max(1, min(self.runtime_config.get("n_workers", 8), 64))


### PR DESCRIPTION
Adding special logging line so that kbmod output goes to `submit_scripts/*.stderr`.
