### PR TITLE
Spawn many small reprojection tasks

### DIFF
--- a/src/kbmod_wf/parallel_repro_single_chip_wf.py
+++ b/src/kbmod_wf/parallel_repro_single_chip_wf.py
@@ -1,0 +1,190 @@
+import argparse
+import os
+from pathlib import Path
+
+import toml
+import parsl
+from parsl import join_app, python_app, File
+import parsl.executors
+
+from kbmod_wf.utilities import (
+    apply_runtime_updates,
+    get_resource_config,
+    get_executors,
+    get_configured_logger,
+)
+
+from kbmod_wf.workflow_tasks import create_manifest, ic_to_wu, kbmod_search
+
+
+# There's still a ton of duplicated code here and in kbmod_wf.workflow_tasks.reproject_wu
+# that should be refactored.
+# The only difference is the import of reproject_single_chip_single_night_wu here.
+@join_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "sharded_reproject"]),
+    ignore_for_cache=["logging_file"],
+)
+def reproject_wu(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+
+    logger = get_configured_logger("task.reproject_wu", logging_file.filepath)
+
+    logger.info("Starting reproject_ic")
+    with ErrorLogger(logger):
+        future = sharded_reproject(
+            original_wu_filepath=inputs[0].filepath,
+            reprojected_wu_filepath=outputs[0].filepath,
+            runtime_config=runtime_config,
+            logger=logger,
+        )
+    logger.info("Completed reproject_ic")
+    return future
+
+
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "sharded_reproject"]),
+    ignore_for_cache=["logging_file"],
+)
+def sharded_reproject(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+
+    logger = get_configured_logger("task.sharded_reproject", logging_file.filepath)
+
+    from kbmod_wf.task_impls.reproject_single_chip_single_night_wu_shard import reproject_wu_shard
+
+    logger.info("Starting reproject_ic")
+    with ErrorLogger(logger):
+        reproject_wu_shard(
+            original_wu_filepath=inputs[0].filepath,
+            reprojected_wu_filepath=outputs[0].filepath,
+            runtime_config=runtime_config,
+            logger=logger,
+        )
+    logger.info("Completed reproject_ic")
+    return outputs[0]
+
+
+def workflow_runner(env=None, runtime_config={}):
+    """This function will load and configure Parsl, and run the workflow.
+
+    Parameters
+    ----------
+    env : str, optional
+        Environment string used to define which resource configuration to use,
+        by default None
+    runtime_config : dict, optional
+        Dictionary of assorted runtime configuration parameters, by default {}
+    """
+    resource_config = get_resource_config(env=env)
+    resource_config = apply_runtime_updates(resource_config, runtime_config)
+
+    app_configs = runtime_config.get("apps", {})
+
+    dfk = parsl.load(resource_config)
+    if dfk:
+        logging_file = File(os.path.join(dfk.run_dir, "kbmod.log"))
+        logger = get_configured_logger("workflow.workflow_runner", logging_file.filepath)
+
+        if runtime_config is not None:
+            logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
+
+        logger.info("Starting workflow")
+
+        # gather all the *.collection files that are staged for processing
+        create_manifest_config = app_configs.get("create_manifest", {})
+        manifest_file = File(
+            os.path.join(create_manifest_config.get("output_directory", os.getcwd()), "manifest.txt")
+        )
+        create_manifest_future = create_manifest(
+            inputs=[],
+            outputs=[manifest_file],
+            runtime_config=app_configs.get("create_manifest", {}),
+            logging_file=logging_file,
+        )
+
+        with open(create_manifest_future.result(), "r") as f:
+            # process each .collection file in the manifest into a .wu file
+            original_work_unit_futures = []
+            for line in f:
+                # Create path object for the line in the manifest
+                input_file = Path(line.strip())
+
+                # Create a directory for the sharded work unit files
+                sharded_directory = Path(input_file.parent, input_file.stem)
+                sharded_directory.mkdir(exist_ok=True)
+
+                # Create the work unit filepath
+                output_workunit_filepath = Path(sharded_directory, input_file.stem + ".wu")
+
+                # Create the work unit future
+                original_work_unit_futures.append(
+                    ic_to_wu(
+                        inputs=[input_file],
+                        outputs=[File(output_workunit_filepath)],
+                        runtime_config=app_configs.get("ic_to_wu", {}),
+                        logging_file=logging_file,
+                    )
+                )
+
+        # reproject each WorkUnit
+        # For chip-by-chip, this isn't really necessary, so hardcoding to 0.
+        reproject_futures = []
+        for f in original_work_unit_futures:
+            distance = 0
+
+            unique_obstimes, unique_obstimes_indices = work_unit.get_unique_obstimes_and_indices()
+
+            reproject_futures.append(
+                reproject_wu(
+                    inputs=[f.result()],
+                    outputs=[File(f.result().filepath + f".{distance}.repro")],
+                    runtime_config=app_configs.get("reproject_wu", {}),
+                    logging_file=logging_file,
+                )
+            )
+
+        # run kbmod search on each reprojected WorkUnit
+        search_futures = []
+        for f in reproject_futures:
+            search_futures.append(
+                kbmod_search(
+                    inputs=[f.result()],
+                    outputs=[File(f.result().filepath + ".search.ecsv")],
+                    runtime_config=app_configs.get("kbmod_search", {}),
+                    logging_file=logging_file,
+                )
+            )
+
+        [f.result() for f in search_futures]
+
+        logger.info("Workflow complete")
+
+    parsl.clear()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--env",
+        type=str,
+        choices=["dev", "klone"],
+        help="The environment to run the workflow in.",
+    )
+
+    parser.add_argument(
+        "--runtime-config",
+        type=str,
+        help="The complete runtime configuration filepath to use for the workflow.",
+    )
+
+    args = parser.parse_args()
+
+    # if a runtime_config file was provided and exists, load the toml as a dict.
+    runtime_config = {}
+    if args.runtime_config is not None and os.path.exists(args.runtime_config):
+        with open(args.runtime_config, "r") as toml_runtime_config:
+            runtime_config = toml.load(toml_runtime_config)
+
+    workflow_runner(env=args.env, runtime_config=runtime_config)

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -9,6 +9,7 @@ walltimes = {
     "compute_bigmem": "01:00:00",
     "large_mem": "04:00:00",
     "sharded_reproject": "04:00:00",
+    "parallel_reproject": "00:30:00",
     "gpu_max": "08:00:00",
 }
 
@@ -76,6 +77,25 @@ def klone_resource_config():
                     mem_per_node=128,  # ~2-4 GB per core
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="parallel_reproject",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-g2",
+                    account="astro",
+                    min_blocks=0,
+                    max_blocks=2,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=1,
+                    mem_per_node=2,  # ~2-4 GB per core
+                    exclusive=False,
+                    walltime=walltimes["parallel_reproject"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="",
                 ),

--- a/src/kbmod_wf/task_impls/reproject_single_chip_single_night_wu_shard.py
+++ b/src/kbmod_wf/task_impls/reproject_single_chip_single_night_wu_shard.py
@@ -1,0 +1,94 @@
+import kbmod
+from kbmod.work_unit import WorkUnit
+
+import kbmod.reprojection as reprojection
+
+from reproject.mosaicking import find_optimal_celestial_wcs
+import os
+import time
+from logging import Logger
+
+
+def reproject_wu_shard(
+    original_wu_shard_filepath: str = None,
+    reprojected_wu_shard_filepath: str = None,
+    runtime_config: dict = {},
+    logger: Logger = None,
+):
+    """This task will reproject a WorkUnit to a common WCS.
+
+    Parameters
+    ----------
+    original_wu_shard_filepath : str, optional
+        The fully resolved filepath to the input WorkUnit file, by default None
+    reprojected_wu_shard_filepath : str, optional
+        The fully resolved filepath to the resulting WorkUnit file after
+        reprojection, by default None
+    runtime_config : dict, optional
+        Additional configuration parameters to be used at runtime, by default {}
+    logger : Logger, optional
+        Primary logger for the workflow, by default None
+
+    Returns
+    -------
+    str
+        The fully resolved filepath of the resulting WorkUnit file after reflex
+        and reprojection.
+    """
+    wu_shard_reprojector = WUShardReprojector(
+        original_wu_filepath=original_wu_shard_filepath,
+        reprojected_wu_filepath=reprojected_wu_shard_filepath,
+        runtime_config=runtime_config,
+        logger=logger,
+    )
+
+    return wu_shard_reprojector.reproject_workunit()
+
+
+class WUShardReprojector:
+    def __init__(
+        self,
+        original_wu_filepath: str = None,
+        reprojected_wu_filepath: str = None,
+        runtime_config: dict = {},
+        logger: Logger = None,
+    ):
+        self.original_wu_filepath = original_wu_filepath
+        self.reprojected_wu_filepath = reprojected_wu_filepath
+        self.runtime_config = runtime_config
+        self.logger = logger
+
+        # Default to 8 workers if not in the config. Value must be 0<num workers<65.
+        self.n_workers = max(1, min(self.runtime_config.get("n_workers", 8), 64))
+
+    def reproject_workunit_shard(self):
+        last_time = time.time()
+        self.logger.info(f"Lazy reading existing WorkUnit from disk: {self.original_wu_filepath}")
+        directory_containing_shards, wu_filename = os.path.split(self.original_wu_filepath)
+        wu = WorkUnit.from_sharded_fits(wu_filename, directory_containing_shards, lazy=True)
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.info(f"Required {elapsed}[s] to lazy read original WorkUnit {self.original_wu_filepath}.")
+
+        directory_containing_reprojected_shards, reprojected_wu_filename = os.path.split(
+            self.reprojected_wu_filepath
+        )
+
+        # Reproject to a common WCS using the WCS for our patch
+        self.logger.info(f"Reprojecting WorkUnit with {self.n_workers} workers...")
+        last_time = time.time()
+
+        opt_wcs, shape = find_optimal_celestial_wcs(list(wu._per_image_wcs))
+        opt_wcs.array_shape = shape
+        reprojection.reproject_work_unit(
+            wu,
+            opt_wcs,
+            max_parallel_processes=self.n_workers,
+            write_output=True,
+            directory=directory_containing_reprojected_shards,
+            filename=reprojected_wu_filename,
+        )
+
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.info(f"Required {elapsed}[s] to create the sharded reprojected WorkUnit.")
+
+        return self.reprojected_wu_filepath


### PR DESCRIPTION
This initial commit begins to assemble a workflow that will generate many small reprojection tasks that each ingest a single workunit shard for reprojection. This allows a task to use only 1 cpu and a small amount of memory instead of 32+ cpus and a large amount of memory. 