### PR TITLE
Deep workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ _html/
 
 # Parsl log files
 run_logs/
+
+# Emacs
+*~

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -18,16 +18,16 @@ def klone_resource_config():
         app_cache=True,
         checkpoint_mode="task_exit",
         checkpoint_files=get_all_checkpoints(
-            os.path.join("/gscratch/dirac/kbmod/workflow/run_logs", datetime.date.today().isoformat())
+            os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat())
         ),
-        run_dir=os.path.join("/gscratch/dirac/kbmod/workflow/run_logs", datetime.date.today().isoformat()),
+        run_dir=os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat()),
         retries=1,
         executors=[
             HighThroughputExecutor(
                 label="small_cpu",
                 max_workers=1,
                 provider=SlurmProvider(
-                    partition="ckpt-g2",
+                    partition="ckpt-all",
                     account="astro",
                     min_blocks=0,
                     max_blocks=4,
@@ -46,7 +46,7 @@ def klone_resource_config():
                 label="large_mem",
                 max_workers=1,
                 provider=SlurmProvider(
-                    partition="ckpt-g2",
+                    partition="ckpt-all",
                     account="astro",
                     min_blocks=0,
                     max_blocks=2,
@@ -54,7 +54,7 @@ def klone_resource_config():
                     parallelism=1,
                     nodes_per_block=1,
                     cores_per_node=32,
-                    mem_per_node=512,
+                    mem_per_node=256,
                     exclusive=False,
                     walltime=walltimes["large_mem"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
@@ -63,17 +63,17 @@ def klone_resource_config():
             ),
             HighThroughputExecutor(
                 label="sharded_reproject",
-                max_workers=1,
+                max_workers=1,  # Do we mean max_workers_per_node here?
                 provider=SlurmProvider(
-                    partition="ckpt-g2",
+                    partition="ckpt-all",
                     account="astro",
                     min_blocks=0,
                     max_blocks=2,
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    cores_per_node=32,
-                    mem_per_node=128,  # ~2-4 GB per core
+                    cores_per_node=8,
+                    mem_per_node=100,
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
@@ -84,15 +84,15 @@ def klone_resource_config():
                 label="gpu",
                 max_workers=1,
                 provider=SlurmProvider(
-                    partition="ckpt-g2",
+                    partition="gpu-a40",
                     account="escience",
                     min_blocks=0,
                     max_blocks=2,
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    cores_per_node=2,  # perhaps should be 8???
-                    mem_per_node=512,  # In GB
+                    cores_per_node=1,  # perhaps should be 8???
+                    mem_per_node=64,  # In GB
                     exclusive=False,
                     walltime=walltimes["gpu_max"],
                     # Command to run before starting worker - i.e. conda activate <special_env>

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -21,7 +21,7 @@ def klone_resource_config():
             os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat())
         ),
         run_dir=os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat()),
-        retries=2,
+        retries=1,
         executors=[
             ####################
             #          Resample resources
@@ -303,7 +303,7 @@ def klone_resource_config():
                     partition="ckpt-all", # ckpt-all
                     account="astro", # astro
                     min_blocks=0,
-                    max_blocks=55, # can leave large at all times
+                    max_blocks=100, # can leave large at all times
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -21,102 +21,298 @@ def klone_resource_config():
             os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat())
         ),
         run_dir=os.path.join(os.path.abspath(os.curdir), datetime.date.today().isoformat()),
-        retries=1,
+        retries=2,
         executors=[
+            ####################
+            #          Resample resources
+            ####################
             HighThroughputExecutor(
-                label="ckpt_96gb_8cpus",
-                max_workers=1,  # Do we mean max_workers_per_node here?
+                label="astro_96gb_8cpus",
+                max_workers=1,
                 provider=SlurmProvider(
-                    partition="gpu-a40", # ckpt-all
-                    account="escience", # astro
+                    partition="compute-bigmem",
+                    account="astro", 
                     min_blocks=0,
-                    max_blocks=5,
+                    max_blocks=4,   # Low block count for shared resource
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    mem_per_node=12, # 96 GB
+                    mem_per_node=96, # 96 GB for >100, 48 for < 100
                     cores_per_node=8,
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="",
                 ),
             ),
             HighThroughputExecutor(
-                label="astro_2gb_2cpus",
-                max_workers=1,  # Do we mean max_workers_per_node here?
+                label="astro_48gb_8cpus",
+                max_workers=1,
                 provider=SlurmProvider(
-                    partition="gpu-a40", # ckpt-all
-                    account="escience", # astro
+                    partition="compute-bigmem",
+                    account="astro",
                     min_blocks=0,
-                    max_blocks=5,
+                    max_blocks=4,   # Low block count for shared resource
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    mem_per_node=4,
-                    cores_per_node=2,
+                    mem_per_node=48, # 96 GB for >100, 48 for < 100
+                    cores_per_node=8,
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="",
                 ),
             ),
             HighThroughputExecutor(
-                label="esci_2gb_2cpus",
-                max_workers=1,  # Do we mean max_workers_per_node here?
-                provider=SlurmProvider(
-                    partition="gpu-a40", # ckpt-all
-                    account="escience", # astro
-                    min_blocks=0,
-                    max_blocks=5,
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    mem_per_node=4,
-                    cores_per_node=2,
-                    exclusive=False,
-                    walltime=walltimes["sharded_reproject"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="ckpt_2gb_2cpus",
-                max_workers=1,  # Do we mean max_workers_per_node here?
-                provider=SlurmProvider(
-                    partition="gpu-a40", # ckpt-all
-                    account="escience", # astro
-                    min_blocks=0,
-                    max_blocks=5,
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    mem_per_node=4,
-                    cores_per_node=2,
-                    exclusive=False,
-                    walltime=walltimes["sharded_reproject"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="gpu",
+                label="esci_96gb_8cpus",
                 max_workers=1,
                 provider=SlurmProvider(
                     partition="gpu-a40",
                     account="escience",
                     min_blocks=0,
-                    max_blocks=4,
+                    max_blocks=4,  # low block count for shared resources
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=96, # 96 GB for >100, 48 for < 100
+                    cores_per_node=8,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="esci_48gb_8cpus",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="gpu-a40",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=4,  # low block count for shared resources
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=48, # 96 GB for >100, 48 for < 100
+                    cores_per_node=8,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_96gb_8cpus",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-all",
+                    account="astro",
+                    min_blocks=0,
+                    max_blocks=50,  # scale to the size of the GPU blocks, big number for low memory
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=96,  # 96 GB for >100, 48 for < 100
+                    cores_per_node=8,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_48gb_8cpus",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-all",
+                    account="astro",
+                    min_blocks=0,
+                    max_blocks=50,  # scale to the size of the GPU blocks, big number for low memory
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=48, # 96 GB for >100, 48 for < 100
+                    cores_per_node=8,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    worker_init="",
+                ),
+            ),
+            ####################
+            #          Search resources
+            ####################
+            HighThroughputExecutor(
+                label="esci_96gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="gpu-a40",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=4,  # low block count for shared resource
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
                     cores_per_node=2,  # perhaps should be 8???
-                    mem_per_node=12,  # 64 In GB
+                    mem_per_node=96,  # 96 GB for >100, 48 for < 100
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="esci_48gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="gpu-a40",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=4,  # low block count for shared resource
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=48,  # 96 GB for >100, 48 for < 100
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="esci_32gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="gpu-a40",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=4,  # low block count for shared resource
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=32,  # 96 GB for >100, 48 for < 100
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_96gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-g2",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=50, # 20 for 96, 50 for 48
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=96, # 96 GB for >100, 48 for < 100
                     exclusive=False,
                     walltime=walltimes["gpu_max"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="",
                     scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_48gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-g2",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=50, # 20 for 96, 50 for 48
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=48, # 96 GB for >100, 48 for < 100
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_32gb_2cpu_1gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ckpt-g2",
+                    account="escience",
+                    min_blocks=0,
+                    max_blocks=50, # 20 for 96, 50 for 48
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=32, # 96 GB for >100, 48 for < 100
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1",
+                ),
+            ),
+
+            ####################
+            #          Analysis resource
+            ####################
+            HighThroughputExecutor(
+                label="astro_4gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="compute-bigmem", # ckpt-all
+                    account="astro", # astro
+                    min_blocks=0,
+                    max_blocks=12, # low block count for shared resource
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="esci_4gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="gpu-a40", # ckpt-all
+                    account="escience", # astro
+                    min_blocks=0,
+                    max_blocks=12, # low block count for shared resource
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_4gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="ckpt-all", # ckpt-all
+                    account="astro", # astro
+                    min_blocks=0,
+                    max_blocks=55, # can leave large at all times
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
                 ),
             ),
         ],

--- a/src/kbmod_wf/resource_configs/klone_configuration.py
+++ b/src/kbmod_wf/resource_configs/klone_configuration.py
@@ -24,56 +24,75 @@ def klone_resource_config():
         retries=1,
         executors=[
             HighThroughputExecutor(
-                label="small_cpu",
-                max_workers=1,
-                provider=SlurmProvider(
-                    partition="ckpt-all",
-                    account="astro",
-                    min_blocks=0,
-                    max_blocks=4,
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    cores_per_node=1,  # perhaps should be 8???
-                    mem_per_node=256,  # In GB
-                    exclusive=False,
-                    walltime=walltimes["compute_bigmem"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="large_mem",
-                max_workers=1,
-                provider=SlurmProvider(
-                    partition="ckpt-all",
-                    account="astro",
-                    min_blocks=0,
-                    max_blocks=2,
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    cores_per_node=32,
-                    mem_per_node=256,
-                    exclusive=False,
-                    walltime=walltimes["large_mem"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="sharded_reproject",
+                label="ckpt_96gb_8cpus",
                 max_workers=1,  # Do we mean max_workers_per_node here?
                 provider=SlurmProvider(
-                    partition="ckpt-all",
-                    account="astro",
+                    partition="gpu-a40", # ckpt-all
+                    account="escience", # astro
                     min_blocks=0,
-                    max_blocks=2,
+                    max_blocks=5,
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
+                    mem_per_node=12, # 96 GB
                     cores_per_node=8,
-                    mem_per_node=100,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="astro_2gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="gpu-a40", # ckpt-all
+                    account="escience", # astro
+                    min_blocks=0,
+                    max_blocks=5,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="esci_2gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="gpu-a40", # ckpt-all
+                    account="escience", # astro
+                    min_blocks=0,
+                    max_blocks=5,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="ckpt_2gb_2cpus",
+                max_workers=1,  # Do we mean max_workers_per_node here?
+                provider=SlurmProvider(
+                    partition="gpu-a40", # ckpt-all
+                    account="escience", # astro
+                    min_blocks=0,
+                    max_blocks=5,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    mem_per_node=4,
+                    cores_per_node=2,
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
@@ -87,24 +106,17 @@ def klone_resource_config():
                     partition="gpu-a40",
                     account="escience",
                     min_blocks=0,
-                    max_blocks=2,
+                    max_blocks=4,
                     init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    cores_per_node=1,  # perhaps should be 8???
-                    mem_per_node=64,  # In GB
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=12,  # 64 In GB
                     exclusive=False,
                     walltime=walltimes["gpu_max"],
                     # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="",
                     scheduler_options="#SBATCH --gpus=1",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="local_thread",
-                provider=LocalProvider(
-                    init_blocks=0,
-                    max_blocks=1,
                 ),
             ),
         ],

--- a/src/kbmod_wf/single_chip_analysis.py
+++ b/src/kbmod_wf/single_chip_analysis.py
@@ -1,0 +1,217 @@
+import logging
+
+from kbmod_wf.utilities import (
+    LOGGING_CONFIG,
+    apply_runtime_updates,
+    get_resource_config,
+    get_executors,
+    get_configured_logger,
+    ErrorLogger,
+    parse_logdir,
+    plot_campaign
+)
+
+logging.config.dictConfig(LOGGING_CONFIG)
+
+import argparse
+import os
+import glob
+
+import toml
+import parsl
+from parsl import python_app, File
+import parsl.executors
+import time
+
+
+#"ckpt_2gb_2cpus", "ckpt_2gb_2cpus", "astro_2gb_2cpus"]),
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "ckpt_4gb_2cpus"]),  
+    ignore_for_cache=["logging_file"],
+)
+def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    """Run postscript actions after each individual task.
+
+    Generally consists of creating analysis plots for each result.
+
+    Parameters
+    ----------
+    inputs : `tuple` or `list`
+        Order sensitive input to the Python App.
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+    runtime_config : `dict`, optional
+        Runtime configuration values. No keys are consumed.
+    logging_file : `File` or `None`, optional
+        Parsl File object poiting to the output logging file.
+
+    Returns
+    -------
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+
+    Inputs
+    ----------
+    result_file : `File`
+         Parsl File object poiting to the associated Results.
+
+    Outputs
+    -------
+    results : `File`
+        Parsl File object poiting to the results.
+    """
+    import tempfile
+    import tarfile
+    import json
+    
+    from astropy.table import Table
+    from astropy.io import fits as fitsio
+    from astropy.wcs import WCS
+    import matplotlib.pyplot as plt
+    
+    from kbmod_wf.task_impls.deep_plots import (
+        Figure,
+        configure_plot,
+        plot_result,
+        select_known_objects
+    )
+
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("kbmod", logging_file.filepath)
+
+    with ErrorLogger(logger):    
+        # Grab some names from the input so we know how to name
+        # our output plots etc.
+        results_path = inputs[0].filepath
+        collname = os.path.basename(results_path).split(".")[0]
+        results = Table.read(results_path)
+        
+        # Grab external resources required
+        # - wcs, times, visitids, fakes, known objects and so on
+        obstimes = results.meta["mjd_mid"]
+        wcs = WCS(json.loads(results.meta["wcs"]))
+
+        fakes = fitsio.open(runtime_config.get(
+            "fake_object_catalog", "fakes_catalog.fits"
+        ))
+        allknowns = Table.read(runtime_config.get(
+            "known_object_catalog", "known_objects_catalog.fits"
+        ))
+
+        fakes, knowns = select_known_objects(fakes, allknowns, results)
+        fakes = fakes.group_by("ORBITID")
+        knowns = knowns.group_by("Name")
+
+        # Make the plots, write them to tmpdir and tar them up
+        allplots = []
+        tmpdir = tempfile.mkdtemp()
+        logger.info(f"Creating analysis plots for results of length: {len(results)}")
+        for i, res in enumerate(results):
+            figure = configure_plot(wcs, fig_kwargs={"figsize": (24, 12)})
+            figure.fig.suptitle(f"{collname}, {res['uuid']}")
+            figure = plot_result(figure, res, fakes, knowns, wcs, obstimes)
+
+            pltname = f"{collname}_L{int(res['likelihood']):0>4}_idx{i:0>4}.jpg"
+            pltpath = os.path.join(tmpdir, pltname)
+            allplots.append(pltpath)
+            logger.info(f"Saving {pltpath}")
+            plt.savefig(pltpath)
+            plt.close(figure.fig)
+            
+        with tarfile.open(outputs[0].filepath, "w|bz2") as tar:
+            for f in allplots:
+                tar.add(f)
+
+    return outputs
+
+
+def workflow_runner(env=None, runtime_config={}):
+    """This function will load and configure Parsl, and run the workflow.
+
+    Parameters
+    ----------
+    env : str, optional
+        Environment string used to define which resource configuration to use,
+        by default None
+    runtime_config : dict, optional
+        Dictionary of assorted runtime configuration parameters, by default {}
+    """
+    resource_config = get_resource_config(env=env)
+    resource_config = apply_runtime_updates(resource_config, runtime_config)
+    app_configs = runtime_config.get("apps", {})
+
+    dfk = parsl.load(resource_config)
+    logger = get_configured_logger("workflow.workflow_runner")
+
+    if dfk:
+        if runtime_config is not None:
+            logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
+
+        results_dirpath = "results"
+        pattern = os.path.join(results_dirpath, "*results*")
+        results = glob.glob(pattern)
+
+        resampledwus_dirpath = "resampled_wus"
+        imgcolls_dirpath = "collections"
+
+        collnames, collfiles, wufiles = [], [], []
+        for respth in results:
+            resname = os.path.basename(respth).split(".")[0]
+            collnames.append(resname)
+
+            pattern = os.path.join(imgcolls_dirpath, resname) + "*"
+            collfiles.extend(glob.glob(pattern))
+            
+            pattern = os.path.join(resampledwus_dirpath, resname) + "*"
+            wufiles.extend(glob.glob(pattern))
+
+        logger.info("Starting workflow")
+        logger.info(f"Found {len(results)} files in {results_dirpath}")
+
+        # Register postscript for each output of step 2
+        analysis = []
+        for result, collname in zip(results, collnames):
+            logger.info(f"Registering {collname} for postscript")
+            logging_file = File(f"analysis_logs/{collname}.analysis.log")
+            plots_archive = File(f"analysis_plots/{collname}.plots.tar.bz2")
+            analysis.append(
+                postscript(
+                    inputs=[File(result)],
+                    outputs=[plots_archive, ],
+                    runtime_config=app_configs.get("postscript", {}),
+                    logging_file=logging_file
+                )
+            )
+    
+        [f.result() for f in analysis]
+        dfk.wait_for_current_tasks()
+        logger.info("Workflow complete")
+    parsl.clear()
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--env",
+        type=str,
+        choices=["dev", "klone"],
+        help="The environment to run the workflow in.",
+    )
+
+    parser.add_argument(
+        "--runtime-config",
+        type=str,
+        help="The complete runtime configuration filepath to use for the workflow.",
+    )
+
+    args = parser.parse_args()
+
+    # if a runtime_config file was provided and exists, load the toml as a dict.
+    runtime_config = {}
+    if args.runtime_config is not None and os.path.exists(args.runtime_config):
+        with open(args.runtime_config, "r") as toml_runtime_config:
+            runtime_config = toml.load(toml_runtime_config)
+
+    workflow_runner(env=args.env, runtime_config=runtime_config)

--- a/src/kbmod_wf/single_chip_step2.py
+++ b/src/kbmod_wf/single_chip_step2.py
@@ -1,0 +1,129 @@
+import logging
+logging.basicConfig(level=logging.INFO)
+
+import argparse
+import os
+import glob
+
+import toml
+import parsl
+from parsl import python_app, File
+import parsl.executors
+import time
+
+from kbmod_wf.utilities import (
+    apply_runtime_updates,
+    get_resource_config,
+    get_executors,
+    get_configured_logger,
+)
+
+
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "gpu"]),
+    ignore_for_cache=["logging_file"],
+)
+def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("task.step2", logging_file.filepath)
+
+    import json
+    
+    from kbmod.work_unit import WorkUnit
+    from kbmod.run_search import SearchRunner
+
+    with ErrorLogger(logger):
+        wu = WorkUnit.from_fits(inputs[0])
+        res = SearchRunner().run_search_from_work_unit(wu)
+
+        # a WCS in the results table would be very helpful
+        # so add it in.
+        header = wu.wcs.to_header(relax=True)
+        h, w = wu.wcs.pixel_shape
+        header["NAXIS1"], header["NAXIS2"] = h, w
+        res.table.meta["wcs"] = json.dumps(dict(header))
+
+        # write the results to a file
+        res.write_table(outputs[0].filepath)
+
+    return outputs
+
+
+def workflow_runner(env=None, runtime_config={}):
+    """This function will load and configure Parsl, and run the workflow.
+
+    Parameters
+    ----------
+    env : str, optional
+        Environment string used to define which resource configuration to use,
+        by default None
+    runtime_config : dict, optional
+        Dictionary of assorted runtime configuration parameters, by default {}
+    """
+    resource_config = get_resource_config(env=env)
+    resource_config = apply_runtime_updates(resource_config, runtime_config)
+    app_configs = runtime_config.get("apps", {})
+                              
+    dfk = parsl.load(resource_config)
+    logger = get_configured_logger("workflow.workflow_runner")
+    
+    if dfk:
+        if runtime_config is not None:
+            logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
+
+        logger.info("Starting workflow")
+        
+        #directory_path = runtime_config.get("staging_directory", "resampled_wus")
+        directory_path = "resampled_wus"
+        file_pattern = "*.wu"
+        pattern = os.path.join(directory_path, file_pattern)
+        entries = glob.glob(pattern)
+        logger.info(f"Found {len(entries)} files in {directory_path}")
+
+        # run kbmod search on each reprojected WorkUnit
+        search_futures = []
+        for workunit in entries:
+            wuname = os.path.basename(workunit)
+            wuname = wuname.split(".")[0]
+            open(f"logs/{wuname}.search.log", "w").close()
+            logging_file = File(f"logs/{wuname}.search.log")
+            search_futures.append(
+                step2(
+                    inputs=[workunit,],
+                    outputs=[File(f"results/{wuname}.results.ecsv")],
+                    runtime_config=app_configs.get("kbmod_search", {}),
+                    logging_file=logging_file,
+                )
+            )
+            
+        [f.result() for f in search_futures]
+        logger.info("Workflow complete")
+
+    parsl.clear()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--env",
+        type=str,
+        choices=["dev", "klone"],
+        help="The environment to run the workflow in.",
+    )
+
+    parser.add_argument(
+        "--runtime-config",
+        type=str,
+        help="The complete runtime configuration filepath to use for the workflow.",
+    )
+
+    args = parser.parse_args()
+
+    # if a runtime_config file was provided and exists, load the toml as a dict.
+    runtime_config = {}
+    if args.runtime_config is not None and os.path.exists(args.runtime_config):
+        with open(args.runtime_config, "r") as toml_runtime_config:
+            runtime_config = toml.load(toml_runtime_config)
+
+    workflow_runner(env=args.env, runtime_config=runtime_config)

--- a/src/kbmod_wf/single_chip_workflow2.py
+++ b/src/kbmod_wf/single_chip_workflow2.py
@@ -23,11 +23,14 @@ from kbmod_wf.utilities import (
     get_resource_config,
     get_executors,
     get_configured_logger,
+    parse_logdir,
+    plot_campaign
 )
+
 
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "ckpt_96gb_8cpus"]),
+    executors=get_executors(["local_dev_testing", "ckpt_48gb_8cpus"]), # "esci_48_8cpus" "astro_48_8cpus"
     ignore_for_cache=["logging_file"],
 )
 def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
@@ -71,7 +74,9 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         # Adjust the search parameters based on the selection
         # currently that's only the n_obs, but could be lh_threshold too
         search_conf = SearchConfiguration.from_file(search_conf_path)
-        search_conf._params["n_obs"] = len(ic)//2
+        #n_obs = len(ic)//2 if len(ic)//2 > 40 else 40
+        n_obs = len(ic)//2
+        search_conf._params["n_obs"] = n_obs
 
         # Fit the optimal WCS
         # TODO: triple check this doesn't flip the array, I'm pretty sure it does
@@ -99,7 +104,7 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
 
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "gpu"]),
+    executors=get_executors(["local_dev_testing", "ckpt_32gb_2cpu_1gpu"]), # "esci_48_2cpu_1gpu", "esci_48_2cpu_1gpu"
     ignore_for_cache=["logging_file"],
 )
 def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
@@ -117,6 +122,7 @@ def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         coll_path = inputs[1].filepath
 
         ic = ImageCollection.read(coll_path)
+        ic.data.sort("mjd_mid")
         wu = WorkUnit.from_fits(wu_path)
         res = SearchRunner().run_search_from_work_unit(wu)
 
@@ -128,7 +134,7 @@ def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         res.table.meta["visits"] = list(ic["visit"].data)
         res.table.meta["detector"] = ic["detector"][0]
         res.table.meta["mjd_mid"] = list(ic["mjd_mid"].data)
-        
+
         # write the results to a file
         res.write_table(outputs[0].filepath, overwrite=True)
 
@@ -137,22 +143,26 @@ def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
 
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "esci_2gb_2cpus"]),#"ckpt_2gb_2cpus", "esci_2gb_2cpus", "astro_2gb_2cpus"]),
+    executors=get_executors(["local_dev_testing", "ckpt_4gb_2cpus"]),#"ckpt_2gb_2cpus", "ckpt_2gb_2cpus", "astro_2gb_2cpus"]),
     ignore_for_cache=["logging_file"],
 )
 def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
-    logger = get_configured_logger("kbmod.search_task", logging_file.filepath)
+    logger = get_configured_logger("kbmod.analysis_task", logging_file.filepath)
 
     import dataclasses
+    import tempfile
+    import tarfile
+    import shutil
 
     import matplotlib.pyplot as plt
     from matplotlib import gridspec
     from matplotlib.gridspec import GridSpec
-    
+
     import numpy as np
     import astropy.io.fits as fitsio
     from astropy.table import Table
+    from astropy.time import Time
     from astropy.coordinates import SkyCoord
     from astropy.wcs import WCS
 
@@ -175,7 +185,16 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         stamp_gs = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 0])
         stamp_gs2 = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 1])
 
+        ax_left = fig.add_subplot(stamp_gs[:])
+        ax_left.axis('off')
+        ax_left.set_title('Coadded cutouts')
+
+        ax_right = fig.add_subplot(stamp_gs2[:])
+        ax_right.axis('off')
+        ax_right.set_title('Coadded cutouts normalized to mean values.')
+
         stamps = np.array([fig.add_subplot(stamp_gs[i]) for i in range(4)])
+        
         for ax in stamps[1:]:
             ax.sharey(stamps[0])
             plt.setp(ax.get_yticklabels(), visible=False)
@@ -201,8 +220,8 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
 
     def result_to_skycoord(res, times, obs_valid, wcs):
         pos, pos_valid = [], []
-        times = Times(times, format="mjd")
-        dt = times - times[0]
+        times = Time(times, format="mjd")
+        dt = (times - times[0]).value
         for i in range(len(obs_valid)):
             newx, newy = res["x"]+i*dt[i]*res["vx"], res["y"]+i*dt[i]*res["vy"]
             if newx < 0 or newy < 0:
@@ -222,11 +241,14 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
             logger.info(f"No results found in {results_path}")
             return
 
-        fakes = fitsio.open("/gscratch/dirac/dinob/workflows/hundo_run/fakes_detections_joined.fits")
+        tmpdir = tempfile.mkdtemp()
+        fakes = fitsio.open("/gscratch/dirac/dinob/workflows/resources/fakes_detections_joined.minified.fits.bz2")
+        allknowns = Table.read("/gscratch/dirac/dinob/workflows/resources/skybot_results_joined.minified.fits.bz2")
         visitids = results.meta["visits"]
         detector = results.meta["detector"]
+        obstimes = results.meta["mjd_mid"]
         wcs = WCS(json.loads(results.meta["wcs"]))
-        
+
         mask = fakes[1].data["CCDNUM"] == detector
         visitmask = fakes[1].data["EXPNUM"][mask] == visitids[0]
         for vid in visitids[1:]:
@@ -235,39 +257,63 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         fakes = fakes.group_by("ORBITID")
 
         (blra, bldec), (tlra, tldec), (trra, trdec), (brra, brdec) = wcs.calc_footprint()
-        for i, res in enumerate(results):            
+        padding = 0.005
+        mask = (allknowns["RA"] > tlra-padding) & (allknowns["RA"] < blra+padding) & (allknowns["DEC"] > bldec-padding) & (allknowns["DEC"] < trdec+padding)
+        knowns = allknowns[mask].group_by("Name")
+
+        allplots = []
+        logger.info(f"Creating analysis plots for results of length: {len(results)}")
+        for i, res in enumerate(results):
             figure = configure_plot(wcs, fig_kwargs={"figsize": (24, 12)})
             figure.fig.suptitle(f"{collname}, idx: {i}")
 
-            set_ast_lbl, set_tno_lbl = False, False
-            for group in fakes.groups:
-                group.sort("mjd_mid")
-                kind = np.unique(group["type"])
-                if len(kind) > 1:
-                    logger.error("More than 1 kind, shouldn't happen!")
-                if group["type"][0] == "tno":
-                    color = "purple"
-                    lbl = "Fake TNO" if not set_tno_lbl else None
-                    set_tno_lbl = True
-                if group["type"][0] == "asteroid":
-                    color = "red"
-                    lbl = "Fake Asteroid" if not set_ast_lbl else None
-                    set_ast_lbl = True
-                pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
-                figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
-                figure.sky.scatter_coord(pos[0], marker="^", color="green")
-            
-            pos, pos_valid = result_to_skycoord(res, res["obs_valid"], wcs)
-            figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, label="Search trj.", color="C0")
+            if len(fakes) > 1:
+                set_ast_lbl, set_tno_lbl = False, False
+                for group in fakes.groups:
+                    group.sort("mjd_mid")
+                    kind = np.unique(group["type"])
+                    if len(kind) > 1:
+                        logger.error("More than 1 kind, shouldn't happen!")
+                    if group["type"][0] == "tno":
+                        color = "purple"
+                        lbl = "Fake TNO" if not set_tno_lbl else None
+                        set_tno_lbl = True
+                    if group["type"][0] == "asteroid":
+                        color = "red"
+                        lbl = "Fake Asteroid" if not set_ast_lbl else None
+                        set_ast_lbl = True
+                    pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
+                    figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
+                    figure.sky.scatter_coord(pos[0], marker="^", color="green")
+
+            if len(knowns) > 1:
+                set_ast_lbl, set_tno_lbl = False, False
+                for group in knowns.groups:
+                    group.sort("mjd_mid")
+                    kind = np.unique(group["Type"])
+                    if "KBO" in group["Type"][0]:
+                        color = "darkorange"
+                        lbl = "Known KBO" if not set_tno_lbl else None
+                        set_tno_lbl = True
+                    else:
+                        color = "chocolate"
+                        lbl = "Known Asteroid" if not set_ast_lbl else None
+                        set_ast_lbl = True
+                    pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
+                    figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
+                    figure.sky.scatter_coord(pos[0], marker="^", color="green")
+
+            pos, pos_valid = result_to_skycoord(res, obstimes, res["obs_valid"], wcs)
+            figure.sky.plot_coord(pos, marker="o", markersize=1, linewidth=1, label="Search trj.", color="C0")
             figure.sky.scatter_coord(pos[0], marker="^", color="green", label="Starting point")
             if sum(pos_valid) > 0:
-                figure.sky.scatter_coord(pos[pos_valid], marker="+", label="Obs. valid", color="C0")
+                figure.sky.scatter_coord(pos[pos_valid], marker="+", alpha=0.25, label="Obs. valid", color="C0")
             figure.sky.plot(
                 [blra, tlra, trra, brra, blra], [bldec, tldec, trdec, brdec, bldec],
                 transform=figure.sky.get_transform("world"),
                 color="black", label="Footprint"
             )
-            figure.sky.legend()
+            figure.sky.legend(loc="upper left", ncols=7)
 
             stamp_types = ("coadd_mean", "coadd_median", "coadd_weighted", "coadd_sum")
             ntype = stamp_types[0]
@@ -289,11 +335,18 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
             )
             figure.likelihood.legend(loc="upper left")
 
-            logger.info(f"Saving plots/{collname}_{i}_L{int(res['likelihood'])}.jpg")
-            plt.savefig(f"plots/{collname}_{i}_L{int(res['likelihood'])}.jpg")
+            pltname = f"{collname}_L{int(res['likelihood']):0>4}_idx{i:0>4}.jpg"
+            pltpath = os.path.join(tmpdir, pltname)
+            allplots.append(pltpath)
+            logger.info(f"Saving {pltpath}")
+            plt.savefig(pltpath)
             plt.close(figure.fig)
             
-    return 
+        with tarfile.open(outputs[0], "w|bz2") as tar:
+            for f in allplots:
+                tar.add(f)
+
+    return outputs
 
 
 def workflow_runner(env=None, runtime_config={}):
@@ -313,7 +366,7 @@ def workflow_runner(env=None, runtime_config={}):
 
     dfk = parsl.load(resource_config)
     logger = get_configured_logger("workflow.workflow_runner")
-    
+
     if dfk:
         if runtime_config is not None:
             logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
@@ -371,19 +424,35 @@ def workflow_runner(env=None, runtime_config={}):
         for result, collname in zip(results, collnames):
             logger.info(f"Registering {collname} for step3")
             logging_file = File(f"logs/{collname}.analysis.log")
+            plots_archive = File(f"plots/{collname}.plots.tar.bz2")
             analysis.append(
                 postscript(
                     inputs=[result],
-                    outputs=[],
+                    outputs=[plots_archive, ],
                     runtime_config=app_configs.get("analysis", {}),
                     logging_file=logging_file
                 )
             )
+            
         [f.result() for f in analysis]
-
+        dfk.wait_for_current_tasks()
         logger.info("Workflow complete")
 
+    import matplotlib.pyplot as plt
+    logs = parse_logdir("logs")
+    fig, ax = plt.subplots(figsize=(15, 15))
+    ax = plot_campaign(
+        ax,
+        logs,
+        relative_to_launch=True,
+        units="hour",
+        name_pos="right+column"
+    )
+    plt.tight_layout()
+    plt.savefig("exec_gantt.png")
+
     parsl.clear()
+
 
 
 if __name__ == "__main__":

--- a/src/kbmod_wf/single_chip_workflow2.py
+++ b/src/kbmod_wf/single_chip_workflow2.py
@@ -1,12 +1,17 @@
 import logging
-logging.basicConfig(
-    level=logging.INFO,
-    filename="kbmod.log",
-    format="[%(asctime)s %(levelname)s %(name)s] %(message)s"
+
+from kbmod_wf.utilities import (
+    LOGGING_CONFIG,
+    apply_runtime_updates,
+    get_resource_config,
+    get_executors,
+    get_configured_logger,
+    ErrorLogger,
+    parse_logdir,
+    plot_campaign
 )
-stdout = logging.StreamHandler()
-stdout.setLevel(logging.INFO)
-logging.getLogger("").addHandler(stdout)
+
+logging.config.dictConfig(LOGGING_CONFIG)
 
 import argparse
 import os
@@ -18,25 +23,44 @@ from parsl import python_app, File
 import parsl.executors
 import time
 
-from kbmod_wf.utilities import (
-    apply_runtime_updates,
-    get_resource_config,
-    get_executors,
-    get_configured_logger,
-    parse_logdir,
-    plot_campaign
-)
 
-
+# "esci_48_8cpus" "astro_48_8cpus"
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "ckpt_48gb_8cpus"]), # "esci_48_8cpus" "astro_48_8cpus"
+    executors=get_executors(["local_dev_testing", "ckpt_48gb_8cpus"]),
     ignore_for_cache=["logging_file"],
 )
 def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
-    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
-    logger = get_configured_logger("kbmod.ic_to_wu", logging_file.filepath)
+    """Create WorkUnit out of an ImageCollection and resample it.
 
+    Parameters
+    ----------
+    inputs : `tuple` or `list`
+        Order sensitive input to the Python App.
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+    runtime_config : `dict`, optional
+        Runtime configuration values. Keys ``butler_config_filepath``,
+        ``search_config_filepath`` and ``n_workers`` will be consumed
+        if they exist.
+    logging_file : `File` or `None`, optional
+        Parsl File object poiting to the output logging file.
+
+    Returns
+    -------
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+
+    Inputs
+    ----------
+    ic_file : `File`
+         Parsl File object pointing to the ImageCollection.
+
+    Outputs
+    -------
+    workunit_path : `File`
+        Parsl File object poiting to the resampled WorkUnit.
+    """
     import numpy as np
     from reproject.mosaicking import find_optimal_celestial_wcs
 
@@ -45,6 +69,9 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     import kbmod.reprojection as reprojection
 
     from lsst.daf.butler import Butler
+
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("workflow.step1", logging_file.filepath)
 
     with ErrorLogger(logger):
         # Unravell inputs
@@ -55,285 +82,208 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         ####
         #    Run core tasks
         ###
-        # Load the image collection and add quality cuts on the data
-        # Zeropoint cuts would be good, but it does then get confusing
-        # because what is run is not the whole collection. The WCS
-        # HAS to be cut, because resampling won't work correctly (not
-        # an error, but scientifically invalid). This should never
-        # happen because we already filter out the bad CCDs in the
-        # workflow. Just in case though....
         ic = ImageCollection.read(ic_file)
 
+        ###    Mask out images that we don't want or can not search through
+        # mask out poor weather images
         #mask_zp = np.logical_and(ic["zeroPoint"] > 27 , ic["zeroPoint"] < 32)
-        mask_wcs_err = ic["wcs_err"] < 1e-04
         #ic = ic[np.logical_and(mask_zp, mask_wcs_err)]
-        ic = ic[mask_wcs_err]
-        ic.reset_lazy_loading_indices()
+
+        # mask out images with WCS error more than 0.1 arcseconds because we
+        # can't trust their resampling can be correct
+        mask_good_wcs_err = ic["wcs_err"] < 1e-04
+        if not all(mask_good_wcs_err):
+            logger.warning("Image collection contains large WCS errors!")
+        #ic = ic[mask_good_wcs_err]
+        #ic.reset_lazy_loading_indices()
         ic.data.sort("mjd_mid")
 
-        # Adjust the search parameters based on the selection
-        # currently that's only the n_obs, but could be lh_threshold too
+        ### Adjust the search parameters based on remaining metadata
         search_conf = SearchConfiguration.from_file(search_conf_path)
-        #n_obs = len(ic)//2 if len(ic)//2 > 40 else 40
-        n_obs = len(ic)//2
+        if len(ic)//2 < 25:
+            n_obs = 15
+        else:
+            n_obs = len(ic)//2
         search_conf._params["n_obs"] = n_obs
 
+        ###    Resampling
         # Fit the optimal WCS
-        # TODO: triple check this doesn't flip the array, I'm pretty sure it does
         opt_wcs, shape = find_optimal_celestial_wcs(list(ic.wcs))
         opt_wcs.array_shape = shape
 
-        # Standardize the images, and put them in a WorkUnit
         butler = Butler(repo_root)
         wu = ic.toWorkUnit(search_config=search_conf, butler=butler)
+        del ic  # we're done with IC, clean it up for memory
 
-        # we've got everything we wanted out of IC, clean it up.
-        del ic
-
-        # Resample the work unit so all pixels point to the same (ra, dec)
         resampled_wu = reprojection.reproject_work_unit(
             wu,
             opt_wcs,
             parallelize=True,
             max_parallel_processes=runtime_config.get("n_workers", 8),
         )
-        resampled_wu.to_fits(outputs[0], overwrite=True)
+        resampled_wu.to_fits(outputs[0].filepath, overwrite=True)
 
     return outputs
 
 
+# "esci_48_2cpu_1gpu", "esci_48_2cpu_1gpu"
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "ckpt_32gb_2cpu_1gpu"]), # "esci_48_2cpu_1gpu", "esci_48_2cpu_1gpu"
+    executors=get_executors(["local_dev_testing", "ckpt_32gb_2cpu_1gpu"]),
     ignore_for_cache=["logging_file"],
 )
 def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
-    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
-    logger = get_configured_logger("kbmod.search_task", logging_file.filepath)
+    """Load an resampled WorkUnit and search through it.
 
+    Parameters
+    ----------
+    inputs : `tuple` or `list`
+        Order sensitive input to the Python App.
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+    runtime_config : `dict`, optional
+        Runtime configuration values. No values are consumed.
+    logging_file : `File` or `None`, optional
+        Parsl File object poiting to the output logging file.
+
+    Returns
+    -------
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+
+    Inputs
+    ----------
+    wu_file : `File`
+         Parsl File object pointing to the WorkUnit.
+    ic_file : `File`
+         Parsl File object poiting to the associated ImageCollection.
+
+    Outputs
+    -------
+    results : `File`
+        Parsl File object poiting to the results.
+    """
     import json
 
     from kbmod import ImageCollection
     from kbmod.work_unit import WorkUnit
     from kbmod.run_search import SearchRunner
 
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("workflow.step2", logging_file.filepath)
+
     with ErrorLogger(logger):
         wu_path = inputs[0][0].filepath
         coll_path = inputs[1].filepath
 
+        # Run the search
         ic = ImageCollection.read(coll_path)
         ic.data.sort("mjd_mid")
         wu = WorkUnit.from_fits(wu_path)
         res = SearchRunner().run_search_from_work_unit(wu)
 
-        # a WCS in the results table would be very helpful
-        # so add it in.
+        # add useful metadata to the results
         header = wu.wcs.to_header(relax=True)
         header["NAXIS1"], header["NAXIS2"] = wu.wcs.pixel_shape
         res.table.meta["wcs"] = json.dumps(dict(header))
         res.table.meta["visits"] = list(ic["visit"].data)
         res.table.meta["detector"] = ic["detector"][0]
         res.table.meta["mjd_mid"] = list(ic["mjd_mid"].data)
+        res.table["uuid"] = [uuid.uuid4().hex for i in range(len(res.table))]
 
-        # write the results to a file
+        # write results
         res.write_table(outputs[0].filepath, overwrite=True)
 
     return outputs
 
 
+#"ckpt_2gb_2cpus", "ckpt_2gb_2cpus", "astro_2gb_2cpus"]),
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "ckpt_4gb_2cpus"]),#"ckpt_2gb_2cpus", "ckpt_2gb_2cpus", "astro_2gb_2cpus"]),
+    executors=get_executors(["local_dev_testing", "ckpt_4gb_2cpus"]),  
     ignore_for_cache=["logging_file"],
 )
 def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
-    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
-    logger = get_configured_logger("kbmod.analysis_task", logging_file.filepath)
+    """Run postscript actions after each individual task.
 
-    import dataclasses
+    Generally consists of creating analysis plots for each result.
+
+    Parameters
+    ----------
+    inputs : `tuple` or `list`
+        Order sensitive input to the Python App.
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+    runtime_config : `dict`, optional
+        Runtime configuration values. No keys are consumed.
+    logging_file : `File` or `None`, optional
+        Parsl File object poiting to the output logging file.
+
+    Returns
+    -------
+    outputs : `tuple` or `list`
+        Order sensitive output of the Python App.
+
+    Inputs
+    ----------
+    result_file : `File`
+         Parsl File object poiting to the associated Results.
+
+    Outputs
+    -------
+    results : `File`
+        Parsl File object poiting to the results.
+    """
     import tempfile
     import tarfile
-    import shutil
-
-    import matplotlib.pyplot as plt
-    from matplotlib import gridspec
-    from matplotlib.gridspec import GridSpec
-
-    import numpy as np
-    import astropy.io.fits as fitsio
+    import json
+    
     from astropy.table import Table
-    from astropy.time import Time
-    from astropy.coordinates import SkyCoord
+    from astropy.io import fits as fitsio
     from astropy.wcs import WCS
+    import matplotlib.pyplot as plt
+    
+    from kbmod_wf.task_impls.deep_plots import (
+        Figure,
+        configure_plot,
+        plot_result,
+        select_known_objects
+    )
 
-    @dataclasses.dataclass
-    class Figure:
-        fig: plt.Figure
-        stamps: list[plt.Axes]
-        normed_stamps: plt.Axes
-        likelihood: plt.Axes
-        psiphi: plt.Axes
-        sky: plt.Axes
-
-    def configure_plot(wcs, fig_kwargs=None, gs_kwargs=None, height_ratios=[1, 1], width_ration=[1, 1], layout="tight"):
-        fig_kwargs = {} if fig_kwargs is None else fig_kwargs
-        gs_kwargs = {} if gs_kwargs is None else gs_kwargs
-
-        fig = plt.figure(layout=layout, **fig_kwargs)
-
-        fig_gs = GridSpec(2, 2, figure=fig,  **gs_kwargs)
-        stamp_gs = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 0])
-        stamp_gs2 = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 1])
-
-        ax_left = fig.add_subplot(stamp_gs[:])
-        ax_left.axis('off')
-        ax_left.set_title('Coadded cutouts')
-
-        ax_right = fig.add_subplot(stamp_gs2[:])
-        ax_right.axis('off')
-        ax_right.set_title('Coadded cutouts normalized to mean values.')
-
-        stamps = np.array([fig.add_subplot(stamp_gs[i]) for i in range(4)])
-        
-        for ax in stamps[1:]:
-            ax.sharey(stamps[0])
-            plt.setp(ax.get_yticklabels(), visible=False)
-
-        normed = np.array([fig.add_subplot(stamp_gs2[i]) for i in range(4)])
-        for ax in normed[1:]:
-            ax.sharey(normed[0])
-            plt.setp(ax.get_yticklabels(), visible=False)
-
-        likelihood = fig.add_subplot(fig_gs[0, 0])
-        psiphi = likelihood.twinx()
-        likelihood.set_ylabel("Likelihood")
-        psiphi.set_ylabel("Psi, Phi value")
-        likelihood.set_xlabel("i-th image in stack")
-
-        sky = fig.add_subplot(fig_gs[0, 1], projection=wcs)
-        overlay = sky.get_coords_overlay('geocentricmeanecliptic')
-        overlay.grid(color='black', ls='dotted')
-        sky.coords[0].set_major_formatter('d.dd')
-        sky.coords[1].set_major_formatter('d.dd')
-
-        return Figure(fig, stamps, normed, likelihood, psiphi, sky)
-
-    def result_to_skycoord(res, times, obs_valid, wcs):
-        pos, pos_valid = [], []
-        times = Time(times, format="mjd")
-        dt = (times - times[0]).value
-        for i in range(len(obs_valid)):
-            newx, newy = res["x"]+i*dt[i]*res["vx"], res["y"]+i*dt[i]*res["vy"]
-            if newx < 0 or newy < 0:
-                continue
-            if newx > wcs.pixel_shape[0] or newy > wcs.pixel_shape[1]:
-                continue
-            pos.append(wcs.pixel_to_world(newx, newy))
-            pos_valid.append(obs_valid[i])
-        return SkyCoord(pos), pos_valid
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("workflow.postscript", logging_file.filepath)
 
     with ErrorLogger(logger):
+        # Grab some names from the input so we know how to name
+        # our output plots etc.
         results_path = inputs[0][0].filepath
         collname = os.path.basename(results_path).split(".")[0]
         results = Table.read(results_path)
-
-        if len(results) == 0:
-            logger.info(f"No results found in {results_path}")
-            return
-
-        tmpdir = tempfile.mkdtemp()
-        fakes = fitsio.open("/gscratch/dirac/dinob/workflows/resources/fakes_detections_joined.minified.fits.bz2")
-        allknowns = Table.read("/gscratch/dirac/dinob/workflows/resources/skybot_results_joined.minified.fits.bz2")
-        visitids = results.meta["visits"]
-        detector = results.meta["detector"]
+        
+        # Grab external resources required
+        # - wcs, times, visitids, fakes, known objects and so on
         obstimes = results.meta["mjd_mid"]
         wcs = WCS(json.loads(results.meta["wcs"]))
 
-        mask = fakes[1].data["CCDNUM"] == detector
-        visitmask = fakes[1].data["EXPNUM"][mask] == visitids[0]
-        for vid in visitids[1:]:
-            visitmask = np.logical_or(visitmask, fakes[1].data["EXPNUM"][mask] == vid)
-        fakes = Table(fakes[1].data[mask][visitmask])
+        fakes = fitsio.open(runtime_config.get(
+            "fake_object_catalog", "fakes_catalog.fits"
+        ))
+        allknowns = Table.read(runtime_config.get(
+            "known_object_catalog", "known_objects_catalog.fits"
+        ))
+
+        fakes, knowns = select_known_objects(fakes, allknowns, results)
         fakes = fakes.group_by("ORBITID")
+        knowns = knowns.group_by("Name")
 
-        (blra, bldec), (tlra, tldec), (trra, trdec), (brra, brdec) = wcs.calc_footprint()
-        padding = 0.005
-        mask = (allknowns["RA"] > tlra-padding) & (allknowns["RA"] < blra+padding) & (allknowns["DEC"] > bldec-padding) & (allknowns["DEC"] < trdec+padding)
-        knowns = allknowns[mask].group_by("Name")
-
+        # Make the plots, write them to tmpdir and tar them up
         allplots = []
+        tmpdir = tempfile.mkdtemp()
         logger.info(f"Creating analysis plots for results of length: {len(results)}")
         for i, res in enumerate(results):
             figure = configure_plot(wcs, fig_kwargs={"figsize": (24, 12)})
-            figure.fig.suptitle(f"{collname}, idx: {i}")
-
-            if len(fakes) > 1:
-                set_ast_lbl, set_tno_lbl = False, False
-                for group in fakes.groups:
-                    group.sort("mjd_mid")
-                    kind = np.unique(group["type"])
-                    if len(kind) > 1:
-                        logger.error("More than 1 kind, shouldn't happen!")
-                    if group["type"][0] == "tno":
-                        color = "purple"
-                        lbl = "Fake TNO" if not set_tno_lbl else None
-                        set_tno_lbl = True
-                    if group["type"][0] == "asteroid":
-                        color = "red"
-                        lbl = "Fake Asteroid" if not set_ast_lbl else None
-                        set_ast_lbl = True
-                    pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
-                    figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
-                    figure.sky.scatter_coord(pos[0], marker="^", color="green")
-
-            if len(knowns) > 1:
-                set_ast_lbl, set_tno_lbl = False, False
-                for group in knowns.groups:
-                    group.sort("mjd_mid")
-                    kind = np.unique(group["Type"])
-                    if "KBO" in group["Type"][0]:
-                        color = "darkorange"
-                        lbl = "Known KBO" if not set_tno_lbl else None
-                        set_tno_lbl = True
-                    else:
-                        color = "chocolate"
-                        lbl = "Known Asteroid" if not set_ast_lbl else None
-                        set_ast_lbl = True
-                    pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
-                    figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
-                    figure.sky.scatter_coord(pos[0], marker="^", color="green")
-
-            pos, pos_valid = result_to_skycoord(res, obstimes, res["obs_valid"], wcs)
-            figure.sky.plot_coord(pos, marker="o", markersize=1, linewidth=1, label="Search trj.", color="C0")
-            figure.sky.scatter_coord(pos[0], marker="^", color="green", label="Starting point")
-            if sum(pos_valid) > 0:
-                figure.sky.scatter_coord(pos[pos_valid], marker="+", alpha=0.25, label="Obs. valid", color="C0")
-            figure.sky.plot(
-                [blra, tlra, trra, brra, blra], [bldec, tldec, trdec, brdec, bldec],
-                transform=figure.sky.get_transform("world"),
-                color="black", label="Footprint"
-            )
-            figure.sky.legend(loc="upper left", ncols=7)
-
-            stamp_types = ("coadd_mean", "coadd_median", "coadd_weighted", "coadd_sum")
-            ntype = stamp_types[0]
-            for ax, kind in zip(figure.stamps.ravel(), stamp_types):
-                ax.imshow(res[kind], interpolation="none")
-                ax.set_title(kind)
-            for ax, kind in zip(figure.normed_stamps.ravel(), stamp_types):
-                ax.imshow(res[kind], vmin=res[ntype].min(), vmax=res[ntype].max(), interpolation="none")
-                ax.set_title(kind)
-
-            figure.psiphi.plot(res["psi_curve"], alpha=0.25, marker="o", label="psi")
-            figure.psiphi.plot(res["phi_curve"], alpha=0.25, marker="o", label="phi")
-            figure.psiphi.legend(loc="upper right")
-
-            figure.likelihood.plot(res["psi_curve"]/res["phi_curve"], marker="o", label="L", color="red")
-            figure.likelihood.set_title(
-                f"Likelihood: {res['likelihood']:.5}, obs_count: {res['obs_count']}, \n "
-                f"(x, y): ({res['x']}, {res['y']}), (vx, vy): ({res['vx']:.6}, {res['vy']:.6})"
-            )
-            figure.likelihood.legend(loc="upper left")
+            figure.fig.suptitle(f"{collname}, {res['uuid']}")
+            figure = plot_result(figure, res, fakes, knowns, wcs, obstimes)
 
             pltname = f"{collname}_L{int(res['likelihood']):0>4}_idx{i:0>4}.jpg"
             pltpath = os.path.join(tmpdir, pltname)
@@ -342,7 +292,7 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
             plt.savefig(pltpath)
             plt.close(figure.fig)
             
-        with tarfile.open(outputs[0], "w|bz2") as tar:
+        with tarfile.open(outputs[0].filepath, "w|bz2") as tar:
             for f in allplots:
                 tar.add(f)
 
@@ -350,7 +300,36 @@ def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
 
 
 def workflow_runner(env=None, runtime_config={}):
-    """This function will load and configure Parsl, and run the workflow.
+    """Find all image collections in the given directory and run KBMOD
+    search on them.
+
+    Running the Workflow is a multi-step process which includes
+    additional preparation and cleanup work that executes at the
+    submit location:
+    - Run prep
+        - Load runtime config
+        - find all files in ``staging_directory`` that match ``pattern``
+        - filter out unwanted files
+    - Run KBMOD Search for each remaining collection
+    - Create a workflow Gantt chart.
+
+    Running a KBMOD search is a 3 step process:
+    - step 1, executed on CPUs
+        - load ImageCollection
+        - filter unwanted rows of data from it
+        - load SearchConfiguration
+        - update search config values based on the IC metadata
+        - materialize a WorkUnit, requires the Rubin Data Butler
+        - resample a WorkUnit, targets the largest common footprint WCS
+        - writes the WorkUnit to file
+    - step 2, executed on GPUs
+        - loads the WorkUnit
+        - runs KBMOD search
+        - adds relevant metadata to the Results Table
+        - writes Results to file
+    - step 3, executed on CPUs
+        - loads Results file
+        - makes an analysis plot
 
     Parameters
     ----------
@@ -362,6 +341,7 @@ def workflow_runner(env=None, runtime_config={}):
     """
     resource_config = get_resource_config(env=env)
     resource_config = apply_runtime_updates(resource_config, runtime_config)
+    workflow_config = runtime_config.get("workflow", {})
     app_configs = runtime_config.get("apps", {})
 
     dfk = parsl.load(resource_config)
@@ -372,41 +352,41 @@ def workflow_runner(env=None, runtime_config={}):
             logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
 
         logger.info("Starting workflow")
-        directory_path = runtime_config.get("staging_directory", "collections")
-        file_pattern = runtime_config.get("file_pattern", "*.collection")
+        
+        directory_path = workflow_config.get("staging_directory", "collections")
+        file_pattern = workflow_config.get("ic_filename_pattern", "*.collection")
         pattern = os.path.join(directory_path, file_pattern)
         entries = glob.glob(pattern)
         logger.info(f"Found {len(entries)} files in {directory_path}")
 
+        skip_ccds = workflow_config.get("skip_ccds", ["002", "031", "061"])
+
         # bookeping, used to build future output filenames
-        collnames = []
-        collfiles = []
-        resampled_wus = []
+        collfiles, collnames, resampled_wus = [], [], []
         for collection in entries:
-            # skip detectors 31, 61 and 2
-            if "002" in collection or "031" in collection or "061" in collection:
-                print(f"Skipping {collection} bad detector.")
+            if any([ccd in collection for ccd in skip_ccds]):
+                logger.warning(f"Skipping {collection} bad detector.")
                 continue
 
             # bookeeping for future tasks
-            collname = os.path.basename(collection)
-            collname = collname.split(".")[0]
+            collname = os.path.basename(collection).split(".")[0]
             collnames.append(collname)
 
-            # task themselvves
+            # Register step 1 for each of the collection file
             logger.info(f"Registering {collname} for step1 of {collection}")
+            logging_file = File(f"logs/{collname}.resample.log")
             collection_file = File(collection)
             collfiles.append(collection_file)
-            logging_file = File(f"logs/{collname}.resample.log")
             resampled_wus.append(
                 step1(
                     inputs=[collection_file],
                     outputs=[File(f"resampled_wus/{collname}.resampled.wu")],
-                    runtime_config=app_configs.get("ic_to_wu", {}),
+                    runtime_config=app_configs.get("step1", {}),
                     logging_file=logging_file,
                 )
             )
 
+        # Register step 2 for each output of step 1
         results = []
         for resample, collname, collfile in zip(resampled_wus, collnames, collfiles):
             logger.info(f"Registering {collname} for step2 of {collfile.filepath}")
@@ -415,29 +395,31 @@ def workflow_runner(env=None, runtime_config={}):
                 step2(
                     inputs=[resample, collfile],
                     outputs=[File(f"results/{collname}.results.ecsv"),],
-                    runtime_config=app_configs.get("kbmod_search", {}),
+                    runtime_config=app_configs.get("step2", {}),
                     logging_file=logging_file,
                 )
             )
 
+        # Register postscript for each output of step 2
         analysis = []
         for result, collname in zip(results, collnames):
-            logger.info(f"Registering {collname} for step3")
+            logger.info(f"Registering {collname} for postscript")
             logging_file = File(f"logs/{collname}.analysis.log")
             plots_archive = File(f"plots/{collname}.plots.tar.bz2")
             analysis.append(
                 postscript(
                     inputs=[result],
                     outputs=[plots_archive, ],
-                    runtime_config=app_configs.get("analysis", {}),
+                    runtime_config=app_configs.get("postscript", {}),
                     logging_file=logging_file
                 )
             )
-            
+
         [f.result() for f in analysis]
         dfk.wait_for_current_tasks()
         logger.info("Workflow complete")
 
+    # Create the Workflow Gantt chart
     import matplotlib.pyplot as plt
     logs = parse_logdir("logs")
     fig, ax = plt.subplots(figsize=(15, 15))

--- a/src/kbmod_wf/single_chip_workflow2.py
+++ b/src/kbmod_wf/single_chip_workflow2.py
@@ -1,0 +1,197 @@
+import argparse
+import os
+import glob
+
+import toml
+import parsl
+from parsl import python_app, File
+import parsl.executors
+
+from kbmod_wf.utilities import (
+    apply_runtime_updates,
+    get_resource_config,
+    get_executors,
+    get_configured_logger,
+)
+
+from kbmod_wf.workflow_tasks import create_manifest, ic_to_wu, kbmod_search
+
+
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "sharded_reproject"]),
+    ignore_for_cache=["logging_file"],
+)
+def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("kbmod.ic_to_wu")
+
+    import numpy as np
+    from reproject.mosaicking import find_optimal_celestial_wcs
+
+    from kbmod import ImageCollection
+    from kbmod.configuration import SearchConfiguration
+    import kbmod.reprojection as reprojection
+
+    from lsst.daf.butler import Butler
+    
+    logger.info(f"Running with config {runtime_config}")
+
+    with ErrorLogger(logger):
+        # Unravell inputs
+        repo_root = runtime_config["butler_config_filepath"]
+        search_conf_path = runtime_config.get("search_config_filepath", None)
+        ic_file = inputs[0].filepath
+
+        # Run core tasks
+        logger.info("Reading ImageCollection and adjusting search limits.")
+        ic = ImageCollection.read(ic_file)
+        ic.data.sort("mjd_mid")
+        butler = Butler(repo_root)
+        search_conf = SearchConfiguration.from_file(search_conf_path)
+
+        # fixup config to match specifics of the image collection in question
+        search_conf._params["n_obs"] = len(ic)/2
+        logger.info(f"Setting search config n_obs to {search_conf._params['n_obs']}")
+        
+        # Fit the optimal WCS
+        # TODO: triple check this doesn't flip the array, I'm pretty sure it does
+        opt_wcs, shape = find_optimal_celestial_wcs(list(ic.wcs))
+        opt_wcs.array_shape = shape
+
+        wu = ic.toWorkUnit(search_config=search_conf, butler=butler, overwrite=True)
+        logger.info("Created a WorkUnit")
+
+        # we've got everything we wanted out of IC, clean it up.
+        del ic
+
+        # Resample the work unit so all pixels point to the same (ra, dec)
+        logger.info(f"Writing resampled wu to {outputs[0]}")
+        resampled_wu = reprojection.reproject_work_unit(
+            wu,
+            opt_wcs,
+            max_parallel_processes=runtime_config.get("n_workers", 8),
+        )
+        resampled_wu.to_fits(outputs[0])
+
+    return outputs
+
+
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "gpu"]),
+    ignore_for_cache=["logging_file"],
+)
+def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("kbmod.search_task", logging_file.filepath)
+
+    import json
+    
+    from kbmod.work_unit import WorkUnit
+    from kbmod.run_search import SearchRunner
+
+    with ErrorLogger(logger):
+        wu = WorkUnit.from_fits(inputs[0].filename)
+        res = SearchRunner().run_search_from_work_unit(wu)
+        header = wu.wcs.to_header(relax=True)
+        h, w = wu.wcs.pixel_shape
+        header["NAXIS1"], header["NAXIS2"] = h, w
+        res.table.meta["wcs"] = json.dumps(dict(header))
+        res.write_table(outputs[0].filename)
+
+    return outputs
+
+
+def workflow_runner(env=None, runtime_config={}):
+    """This function will load and configure Parsl, and run the workflow.
+
+    Parameters
+    ----------
+    env : str, optional
+        Environment string used to define which resource configuration to use,
+        by default None
+    runtime_config : dict, optional
+        Dictionary of assorted runtime configuration parameters, by default {}
+    """
+    resource_config = get_resource_config(env=env)
+                              
+    resource_config = apply_runtime_updates(resource_config, runtime_config)
+                              
+
+    app_configs = runtime_config.get("apps", {})
+                              
+
+    dfk = parsl.load(resource_config)
+                              
+    if dfk:
+        logging_file = File(os.path.join(dfk.run_dir, "kbmod.log"))
+        logger = get_configured_logger("workflow.workflow_runner", logging_file.filepath)
+
+        if runtime_config is not None:
+            logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
+
+        logger.info("Starting workflow")
+        
+        directory_path = runtime_config.get("staging_directory", ".")
+        file_pattern = runtime_config.get("file_pattern", "*.collection")
+        pattern = os.path.join(directory_path, file_pattern)
+        entries = glob.glob(pattern)
+        logger.info(f"Found {len(entries)} files in {directory_path}")
+
+        step1_futures = []
+        for collection in entries:
+            collection_file = File(collection)
+            collname = os.path.basename(collection)
+            collname = collname.split(".")[0]
+            step1_futures.append(
+                step1(
+                    inputs=[collection_file],
+                    outputs=[File(f"{collname}_resampled.wu")],
+                    runtime_config=app_configs.get("ic_to_wu", {}),
+                    logging_file=logging_file,
+                )
+            )
+
+        # run kbmod search on each reprojected WorkUnit
+        search_futures = []
+        for resampled_future in step1_futures:
+            search_futures.append(
+                step2(
+                    inputs=resampled_future.result(),
+                    outputs=[File(resampled_future.result()[0].filepath + ".results.ecsv")],
+                    runtime_config=app_configs.get("kbmod_search", {}),
+                    logging_file=logging_file,
+                )
+            )
+            
+        [f.result() for f in search_futures]
+        logger.info("Workflow complete")
+
+    parsl.clear()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--env",
+        type=str,
+        choices=["dev", "klone"],
+        help="The environment to run the workflow in.",
+    )
+
+    parser.add_argument(
+        "--runtime-config",
+        type=str,
+        help="The complete runtime configuration filepath to use for the workflow.",
+    )
+
+    args = parser.parse_args()
+
+    # if a runtime_config file was provided and exists, load the toml as a dict.
+    runtime_config = {}
+    if args.runtime_config is not None and os.path.exists(args.runtime_config):
+        with open(args.runtime_config, "r") as toml_runtime_config:
+            runtime_config = toml.load(toml_runtime_config)
+
+    workflow_runner(env=args.env, runtime_config=runtime_config)

--- a/src/kbmod_wf/single_chip_workflow2.py
+++ b/src/kbmod_wf/single_chip_workflow2.py
@@ -1,3 +1,13 @@
+import logging
+logging.basicConfig(
+    level=logging.INFO,
+    filename="kbmod.log",
+    format="[%(asctime)s %(levelname)s %(name)s] %(message)s"
+)
+stdout = logging.StreamHandler()
+stdout.setLevel(logging.INFO)
+logging.getLogger("").addHandler(stdout)
+
 import argparse
 import os
 import glob
@@ -6,6 +16,7 @@ import toml
 import parsl
 from parsl import python_app, File
 import parsl.executors
+import time
 
 from kbmod_wf.utilities import (
     apply_runtime_updates,
@@ -14,17 +25,14 @@ from kbmod_wf.utilities import (
     get_configured_logger,
 )
 
-from kbmod_wf.workflow_tasks import create_manifest, ic_to_wu, kbmod_search
-
-
 @python_app(
     cache=True,
-    executors=get_executors(["local_dev_testing", "sharded_reproject"]),
+    executors=get_executors(["local_dev_testing", "ckpt_96gb_8cpus"]),
     ignore_for_cache=["logging_file"],
 )
 def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
-    logger = get_configured_logger("kbmod.ic_to_wu")
+    logger = get_configured_logger("kbmod.ic_to_wu", logging_file.filepath)
 
     import numpy as np
     from reproject.mosaicking import find_optimal_celestial_wcs
@@ -34,8 +42,6 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     import kbmod.reprojection as reprojection
 
     from lsst.daf.butler import Butler
-    
-    logger.info(f"Running with config {runtime_config}")
 
     with ErrorLogger(logger):
         # Unravell inputs
@@ -43,36 +49,50 @@ def step1(inputs=(), outputs=(), runtime_config={}, logging_file=None):
         search_conf_path = runtime_config.get("search_config_filepath", None)
         ic_file = inputs[0].filepath
 
-        # Run core tasks
-        logger.info("Reading ImageCollection and adjusting search limits.")
+        ####
+        #    Run core tasks
+        ###
+        # Load the image collection and add quality cuts on the data
+        # Zeropoint cuts would be good, but it does then get confusing
+        # because what is run is not the whole collection. The WCS
+        # HAS to be cut, because resampling won't work correctly (not
+        # an error, but scientifically invalid). This should never
+        # happen because we already filter out the bad CCDs in the
+        # workflow. Just in case though....
         ic = ImageCollection.read(ic_file)
-        ic.data.sort("mjd_mid")
-        butler = Butler(repo_root)
-        search_conf = SearchConfiguration.from_file(search_conf_path)
 
-        # fixup config to match specifics of the image collection in question
-        search_conf._params["n_obs"] = len(ic)/2
-        logger.info(f"Setting search config n_obs to {search_conf._params['n_obs']}")
-        
+        #mask_zp = np.logical_and(ic["zeroPoint"] > 27 , ic["zeroPoint"] < 32)
+        mask_wcs_err = ic["wcs_err"] < 1e-04
+        #ic = ic[np.logical_and(mask_zp, mask_wcs_err)]
+        ic = ic[mask_wcs_err]
+        ic.reset_lazy_loading_indices()
+        ic.data.sort("mjd_mid")
+
+        # Adjust the search parameters based on the selection
+        # currently that's only the n_obs, but could be lh_threshold too
+        search_conf = SearchConfiguration.from_file(search_conf_path)
+        search_conf._params["n_obs"] = len(ic)//2
+
         # Fit the optimal WCS
         # TODO: triple check this doesn't flip the array, I'm pretty sure it does
         opt_wcs, shape = find_optimal_celestial_wcs(list(ic.wcs))
         opt_wcs.array_shape = shape
 
-        wu = ic.toWorkUnit(search_config=search_conf, butler=butler, overwrite=True)
-        logger.info("Created a WorkUnit")
+        # Standardize the images, and put them in a WorkUnit
+        butler = Butler(repo_root)
+        wu = ic.toWorkUnit(search_config=search_conf, butler=butler)
 
         # we've got everything we wanted out of IC, clean it up.
         del ic
 
         # Resample the work unit so all pixels point to the same (ra, dec)
-        logger.info(f"Writing resampled wu to {outputs[0]}")
         resampled_wu = reprojection.reproject_work_unit(
             wu,
             opt_wcs,
+            parallelize=True,
             max_parallel_processes=runtime_config.get("n_workers", 8),
         )
-        resampled_wu.to_fits(outputs[0])
+        resampled_wu.to_fits(outputs[0], overwrite=True)
 
     return outputs
 
@@ -87,20 +107,193 @@ def step2(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     logger = get_configured_logger("kbmod.search_task", logging_file.filepath)
 
     import json
-    
+
+    from kbmod import ImageCollection
     from kbmod.work_unit import WorkUnit
     from kbmod.run_search import SearchRunner
 
     with ErrorLogger(logger):
-        wu = WorkUnit.from_fits(inputs[0].filename)
+        wu_path = inputs[0][0].filepath
+        coll_path = inputs[1].filepath
+
+        ic = ImageCollection.read(coll_path)
+        wu = WorkUnit.from_fits(wu_path)
         res = SearchRunner().run_search_from_work_unit(wu)
+
+        # a WCS in the results table would be very helpful
+        # so add it in.
         header = wu.wcs.to_header(relax=True)
-        h, w = wu.wcs.pixel_shape
-        header["NAXIS1"], header["NAXIS2"] = h, w
+        header["NAXIS1"], header["NAXIS2"] = wu.wcs.pixel_shape
         res.table.meta["wcs"] = json.dumps(dict(header))
-        res.write_table(outputs[0].filename)
+        res.table.meta["visits"] = list(ic["visit"].data)
+        res.table.meta["detector"] = ic["detector"][0]
+        res.table.meta["mjd_mid"] = list(ic["mjd_mid"].data)
+        
+        # write the results to a file
+        res.write_table(outputs[0].filepath, overwrite=True)
 
     return outputs
+
+
+@python_app(
+    cache=True,
+    executors=get_executors(["local_dev_testing", "esci_2gb_2cpus"]),#"ckpt_2gb_2cpus", "esci_2gb_2cpus", "astro_2gb_2cpus"]),
+    ignore_for_cache=["logging_file"],
+)
+def postscript(inputs=(), outputs=(), runtime_config={}, logging_file=None):
+    from kbmod_wf.utilities.logger_utilities import get_configured_logger, ErrorLogger
+    logger = get_configured_logger("kbmod.search_task", logging_file.filepath)
+
+    import dataclasses
+
+    import matplotlib.pyplot as plt
+    from matplotlib import gridspec
+    from matplotlib.gridspec import GridSpec
+    
+    import numpy as np
+    import astropy.io.fits as fitsio
+    from astropy.table import Table
+    from astropy.coordinates import SkyCoord
+    from astropy.wcs import WCS
+
+    @dataclasses.dataclass
+    class Figure:
+        fig: plt.Figure
+        stamps: list[plt.Axes]
+        normed_stamps: plt.Axes
+        likelihood: plt.Axes
+        psiphi: plt.Axes
+        sky: plt.Axes
+
+    def configure_plot(wcs, fig_kwargs=None, gs_kwargs=None, height_ratios=[1, 1], width_ration=[1, 1], layout="tight"):
+        fig_kwargs = {} if fig_kwargs is None else fig_kwargs
+        gs_kwargs = {} if gs_kwargs is None else gs_kwargs
+
+        fig = plt.figure(layout=layout, **fig_kwargs)
+
+        fig_gs = GridSpec(2, 2, figure=fig,  **gs_kwargs)
+        stamp_gs = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 0])
+        stamp_gs2 = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 1])
+
+        stamps = np.array([fig.add_subplot(stamp_gs[i]) for i in range(4)])
+        for ax in stamps[1:]:
+            ax.sharey(stamps[0])
+            plt.setp(ax.get_yticklabels(), visible=False)
+
+        normed = np.array([fig.add_subplot(stamp_gs2[i]) for i in range(4)])
+        for ax in normed[1:]:
+            ax.sharey(normed[0])
+            plt.setp(ax.get_yticklabels(), visible=False)
+
+        likelihood = fig.add_subplot(fig_gs[0, 0])
+        psiphi = likelihood.twinx()
+        likelihood.set_ylabel("Likelihood")
+        psiphi.set_ylabel("Psi, Phi value")
+        likelihood.set_xlabel("i-th image in stack")
+
+        sky = fig.add_subplot(fig_gs[0, 1], projection=wcs)
+        overlay = sky.get_coords_overlay('geocentricmeanecliptic')
+        overlay.grid(color='black', ls='dotted')
+        sky.coords[0].set_major_formatter('d.dd')
+        sky.coords[1].set_major_formatter('d.dd')
+
+        return Figure(fig, stamps, normed, likelihood, psiphi, sky)
+
+    def result_to_skycoord(res, times, obs_valid, wcs):
+        pos, pos_valid = [], []
+        times = Times(times, format="mjd")
+        dt = times - times[0]
+        for i in range(len(obs_valid)):
+            newx, newy = res["x"]+i*dt[i]*res["vx"], res["y"]+i*dt[i]*res["vy"]
+            if newx < 0 or newy < 0:
+                continue
+            if newx > wcs.pixel_shape[0] or newy > wcs.pixel_shape[1]:
+                continue
+            pos.append(wcs.pixel_to_world(newx, newy))
+            pos_valid.append(obs_valid[i])
+        return SkyCoord(pos), pos_valid
+
+    with ErrorLogger(logger):
+        results_path = inputs[0][0].filepath
+        collname = os.path.basename(results_path).split(".")[0]
+        results = Table.read(results_path)
+
+        if len(results) == 0:
+            logger.info(f"No results found in {results_path}")
+            return
+
+        fakes = fitsio.open("/gscratch/dirac/dinob/workflows/hundo_run/fakes_detections_joined.fits")
+        visitids = results.meta["visits"]
+        detector = results.meta["detector"]
+        wcs = WCS(json.loads(results.meta["wcs"]))
+        
+        mask = fakes[1].data["CCDNUM"] == detector
+        visitmask = fakes[1].data["EXPNUM"][mask] == visitids[0]
+        for vid in visitids[1:]:
+            visitmask = np.logical_or(visitmask, fakes[1].data["EXPNUM"][mask] == vid)
+        fakes = Table(fakes[1].data[mask][visitmask])
+        fakes = fakes.group_by("ORBITID")
+
+        (blra, bldec), (tlra, tldec), (trra, trdec), (brra, brdec) = wcs.calc_footprint()
+        for i, res in enumerate(results):            
+            figure = configure_plot(wcs, fig_kwargs={"figsize": (24, 12)})
+            figure.fig.suptitle(f"{collname}, idx: {i}")
+
+            set_ast_lbl, set_tno_lbl = False, False
+            for group in fakes.groups:
+                group.sort("mjd_mid")
+                kind = np.unique(group["type"])
+                if len(kind) > 1:
+                    logger.error("More than 1 kind, shouldn't happen!")
+                if group["type"][0] == "tno":
+                    color = "purple"
+                    lbl = "Fake TNO" if not set_tno_lbl else None
+                    set_tno_lbl = True
+                if group["type"][0] == "asteroid":
+                    color = "red"
+                    lbl = "Fake Asteroid" if not set_ast_lbl else None
+                    set_ast_lbl = True
+                pos = SkyCoord(group["RA"], group["DEC"], unit="degree", frame="icrs")
+                figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, color=color, label=lbl)
+                figure.sky.scatter_coord(pos[0], marker="^", color="green")
+            
+            pos, pos_valid = result_to_skycoord(res, res["obs_valid"], wcs)
+            figure.sky.plot_coord(pos, marker="o", markersize=2, linewidth=1, label="Search trj.", color="C0")
+            figure.sky.scatter_coord(pos[0], marker="^", color="green", label="Starting point")
+            if sum(pos_valid) > 0:
+                figure.sky.scatter_coord(pos[pos_valid], marker="+", label="Obs. valid", color="C0")
+            figure.sky.plot(
+                [blra, tlra, trra, brra, blra], [bldec, tldec, trdec, brdec, bldec],
+                transform=figure.sky.get_transform("world"),
+                color="black", label="Footprint"
+            )
+            figure.sky.legend()
+
+            stamp_types = ("coadd_mean", "coadd_median", "coadd_weighted", "coadd_sum")
+            ntype = stamp_types[0]
+            for ax, kind in zip(figure.stamps.ravel(), stamp_types):
+                ax.imshow(res[kind], interpolation="none")
+                ax.set_title(kind)
+            for ax, kind in zip(figure.normed_stamps.ravel(), stamp_types):
+                ax.imshow(res[kind], vmin=res[ntype].min(), vmax=res[ntype].max(), interpolation="none")
+                ax.set_title(kind)
+
+            figure.psiphi.plot(res["psi_curve"], alpha=0.25, marker="o", label="psi")
+            figure.psiphi.plot(res["phi_curve"], alpha=0.25, marker="o", label="phi")
+            figure.psiphi.legend(loc="upper right")
+
+            figure.likelihood.plot(res["psi_curve"]/res["phi_curve"], marker="o", label="L", color="red")
+            figure.likelihood.set_title(
+                f"Likelihood: {res['likelihood']:.5}, obs_count: {res['obs_count']}, \n "
+                f"(x, y): ({res['x']}, {res['y']}), (vx, vy): ({res['vx']:.6}, {res['vy']:.6})"
+            )
+            figure.likelihood.legend(loc="upper left")
+
+            logger.info(f"Saving plots/{collname}_{i}_L{int(res['likelihood'])}.jpg")
+            plt.savefig(f"plots/{collname}_{i}_L{int(res['likelihood'])}.jpg")
+            plt.close(figure.fig)
+            
+    return 
 
 
 def workflow_runner(env=None, runtime_config={}):
@@ -115,57 +308,79 @@ def workflow_runner(env=None, runtime_config={}):
         Dictionary of assorted runtime configuration parameters, by default {}
     """
     resource_config = get_resource_config(env=env)
-                              
     resource_config = apply_runtime_updates(resource_config, runtime_config)
-                              
-
     app_configs = runtime_config.get("apps", {})
-                              
 
     dfk = parsl.load(resource_config)
-                              
+    logger = get_configured_logger("workflow.workflow_runner")
+    
     if dfk:
-        logging_file = File(os.path.join(dfk.run_dir, "kbmod.log"))
-        logger = get_configured_logger("workflow.workflow_runner", logging_file.filepath)
-
         if runtime_config is not None:
             logger.info(f"Using runtime configuration definition:\n{toml.dumps(runtime_config)}")
 
         logger.info("Starting workflow")
-        
-        directory_path = runtime_config.get("staging_directory", ".")
+        directory_path = runtime_config.get("staging_directory", "collections")
         file_pattern = runtime_config.get("file_pattern", "*.collection")
         pattern = os.path.join(directory_path, file_pattern)
         entries = glob.glob(pattern)
         logger.info(f"Found {len(entries)} files in {directory_path}")
 
-        step1_futures = []
+        # bookeping, used to build future output filenames
+        collnames = []
+        collfiles = []
+        resampled_wus = []
         for collection in entries:
-            collection_file = File(collection)
+            # skip detectors 31, 61 and 2
+            if "002" in collection or "031" in collection or "061" in collection:
+                print(f"Skipping {collection} bad detector.")
+                continue
+
+            # bookeeping for future tasks
             collname = os.path.basename(collection)
             collname = collname.split(".")[0]
-            step1_futures.append(
+            collnames.append(collname)
+
+            # task themselvves
+            logger.info(f"Registering {collname} for step1 of {collection}")
+            collection_file = File(collection)
+            collfiles.append(collection_file)
+            logging_file = File(f"logs/{collname}.resample.log")
+            resampled_wus.append(
                 step1(
                     inputs=[collection_file],
-                    outputs=[File(f"{collname}_resampled.wu")],
+                    outputs=[File(f"resampled_wus/{collname}.resampled.wu")],
                     runtime_config=app_configs.get("ic_to_wu", {}),
                     logging_file=logging_file,
                 )
             )
 
-        # run kbmod search on each reprojected WorkUnit
-        search_futures = []
-        for resampled_future in step1_futures:
-            search_futures.append(
+        results = []
+        for resample, collname, collfile in zip(resampled_wus, collnames, collfiles):
+            logger.info(f"Registering {collname} for step2 of {collfile.filepath}")
+            logging_file = File(f"logs/{collname}.search.log")
+            results.append(
                 step2(
-                    inputs=resampled_future.result(),
-                    outputs=[File(resampled_future.result()[0].filepath + ".results.ecsv")],
+                    inputs=[resample, collfile],
+                    outputs=[File(f"results/{collname}.results.ecsv"),],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )
             )
-            
-        [f.result() for f in search_futures]
+
+        analysis = []
+        for result, collname in zip(results, collnames):
+            logger.info(f"Registering {collname} for step3")
+            logging_file = File(f"logs/{collname}.analysis.log")
+            analysis.append(
+                postscript(
+                    inputs=[result],
+                    outputs=[],
+                    runtime_config=app_configs.get("analysis", {}),
+                    logging_file=logging_file
+                )
+            )
+        [f.result() for f in analysis]
+
         logger.info("Workflow complete")
 
     parsl.clear()

--- a/src/kbmod_wf/task_impls/deep_plots.py
+++ b/src/kbmod_wf/task_impls/deep_plots.py
@@ -1,0 +1,418 @@
+import dataclasses
+import json
+
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+from matplotlib.gridspec import GridSpec
+
+import numpy as np
+from astropy.table import Table
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
+
+
+__all__ = [
+    "Figure",
+    "configure_plot",
+    "plot_result",
+    "result_to_skycoord",
+    "select_known_objects",
+    "plot_objects",
+    "plot_result"
+]
+
+
+KNOWN_OBJECTS_PLTSTYLE = {
+    "fakes": {
+        "tno": {
+            "color": "purple",
+            "label": "Fake TNO",
+            "linewidth": 1,
+            "markersize": 2,
+            "marker": "o",
+            "start_marker": "^",
+            "start_color": "green"
+        },
+        "asteroid": {
+            "color": "red",
+            "label": "Fake Asteroid",
+            "linewidth": 1,
+            "markersize": 2,
+            "marker": "o",
+            "start_marker": "^",
+            "start_color": "green"
+        }
+    },
+    "knowns": {
+        "KBO": {
+            "color": "darkorange",
+            "label": "Known KBO",
+            "linewidth": 1,
+            "markersize": 2,
+            "marker": "o",
+            "start_marker": "^",
+            "start_color": "green"
+        },
+        "*": {
+            "color": "chocolate",
+            "label": "Known object",
+            "linewidth": 1,
+            "markersize": 2,
+            "marker": "o",
+            "start_marker": "^",
+            "start_color": "green"
+        }
+    }
+}
+"""Default plot style for known objects."""
+
+
+@dataclasses.dataclass
+class Figure:
+    """Figure area containing Axes named ``likelihood``, ``sky``,
+    ``stamps`` and ``normed_stamps`` and ``psiphi`` axis, twinned to
+    ``likelihood``.
+
+    The class does not define a layout, nor data, for these axes,
+    just their content.
+    """
+    fig: plt.Figure
+    stamps: list[plt.Axes]
+    normed_stamps: plt.Axes
+    likelihood: plt.Axes
+    psiphi: plt.Axes
+    sky: plt.Axes
+
+
+def configure_plot(
+        wcs,
+        fig_kwargs=None,
+        gs_kwargs=None,
+        layout="tight"
+):
+    """Configure a `Figure` and place `Axes` within that figure.
+
+    The returned plot area is a 2x2 layout, with axes named
+    ``likelihood``, ``sky``, ``stamps`` and ``normed_stamps``, going
+    in clockwise direction. The top left axis has a twinned y axis
+    named ``psiphi``. The stamps are 1x4 Axes with no axis labels or
+    ticks.
+
+    This function only provides this layout and it does not plot data.
+ 
+    Parameters
+    ----------
+    wcs : `WCS`
+        WCS class to added to ``sky`` axis.
+    fig_kwargs : `dict` or `None`, optional
+        Keyword arguments passed forwards to `plt.figure`.
+    gs_kwargs : `dict` or `None`, optional
+        Keyword arguments passed forwards to `GridSpec`.
+    layout: `str`, optional
+        Figure layout is by default ``tight``.
+
+    Returns
+    -------
+    Figure : `obj`
+       Dataclass containing all of the created Axes, see `Figure`
+    """
+    fig_kwargs = {} if fig_kwargs is None else fig_kwargs
+    lk = fig_kwargs.pop("layout", None)
+    layout = "tight" if lk is None else lk
+    gs_kwargs = {} if gs_kwargs is None else gs_kwargs
+
+    fig = plt.figure(layout=layout, **fig_kwargs)
+
+    fig_gs = GridSpec(2, 2, figure=fig,  **gs_kwargs)
+    stamp_gs = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 0])
+    stamp_gs2 = gridspec.GridSpecFromSubplotSpec(1, 4, hspace=0.01, wspace=0.01, subplot_spec=fig_gs[1, 1])
+
+    ax_left = fig.add_subplot(stamp_gs[:])
+    ax_left.axis('off')
+    ax_left.set_title('Coadded cutouts')
+
+    ax_right = fig.add_subplot(stamp_gs2[:])
+    ax_right.axis('off')
+    ax_right.set_title('Coadded cutouts normalized to mean values.')
+
+    stamps = np.array([fig.add_subplot(stamp_gs[i]) for i in range(4)])
+    
+    for ax in stamps[1:]:
+        ax.sharey(stamps[0])
+        plt.setp(ax.get_yticklabels(), visible=False)
+
+    normed = np.array([fig.add_subplot(stamp_gs2[i]) for i in range(4)])
+    for ax in normed[1:]:
+        ax.sharey(normed[0])
+        plt.setp(ax.get_yticklabels(), visible=False)
+
+    likelihood = fig.add_subplot(fig_gs[0, 0])
+    psiphi = likelihood.twinx()
+    likelihood.set_ylabel("Likelihood")
+    psiphi.set_ylabel("Psi, Phi value")
+    likelihood.set_xlabel("i-th image in stack")
+
+    sky = fig.add_subplot(fig_gs[0, 1], projection=wcs)
+    overlay = sky.get_coords_overlay('geocentricmeanecliptic')
+    overlay.grid(color='black', ls='dotted')
+    sky.coords[0].set_major_formatter('d.dd')
+    sky.coords[1].set_major_formatter('d.dd')
+
+    return Figure(fig, stamps, normed, likelihood, psiphi, sky)
+
+
+def result_to_skycoord(result, times, obs_valid, wcs):
+    """Return a collection of on-sky coordinates that match the result.
+
+    Take a result entry and return its SkyCoord positions on the sky.
+
+    Parameters
+    ----------
+    results : `Row`
+        Result
+    times : `np.array`
+        Array of MJD timestamps as floats.
+    obs_valid : `list[bool]`
+        A list of which observations are valid.
+    wcs : `WCS`
+        WCS
+
+    Returns
+    -------
+    coords : `SkyCoord`
+        World coordinates.
+    pos_valid : `list[bool]`
+        List of valid observations.
+    """
+    pos, pos_valid = [], []
+    times = Time(times, format="mjd")
+    dt = (times - times[0]).value
+
+    newx = result["x"]+dt*result["vx"]
+    newy = result["y"]+dt*result["vy"]
+    coord = wcs.pixel_to_world(newx, newy)
+    #pos.append(list(zip(coord.ra.deg, coord.dec.deg)))
+    #pos_valid.append(obs_valid)                        # NOTE TO SELF: FIX LATER
+
+    return coord, obs_valid #SkyCoord(pos), pos_valid
+
+
+def select_known_objects(fakes, known_objs, results):
+    """Select known objects and known inserted fake objects.
+
+    Parameters
+    ----------
+    fakes : `Table`
+        Table containing visit and detector columns to match on.
+    known_objs : `Table`
+        SkyBot results containing ephemeris of all known objects at
+        the same timestamps.
+    results: `Results`
+        Results
+
+    Returns
+    -------
+    fakes : `Table`
+        Filtered ingoing table of fakes.
+    knowns : `Table`
+        Filetered ingoing table of knwon objects.
+    """
+    visitids = results.meta["visits"]
+    detector = results.meta["detector"]
+    obstimes = results.meta["mjd_mid"]
+    wcs = WCS(json.loads(results.meta["wcs"]))
+
+    mask = fakes[1].data["CCDNUM"] == detector
+    visitmask = fakes[1].data["EXPNUM"][mask] == visitids[0]
+    for vid in visitids[1:]:
+        visitmask = np.logical_or(
+            visitmask,
+            fakes[1].data["EXPNUM"][mask] == vid
+        )
+    fakes = Table(fakes[1].data[mask][visitmask])
+    fakes = fakes.group_by("ORBITID")
+
+    (blra, bldec), (tlra, tldec), (trra, trdec), (brra, brdec) = wcs.calc_footprint()
+    padding = 0.005
+    mask = (
+        (known_objs["RA"] > tlra-padding) &
+        (known_objs["RA"] < blra+padding) &
+        (known_objs["DEC"] > bldec-padding) &
+        (known_objs["DEC"] < trdec+padding)
+    )
+    knowns = known_objs[mask].group_by("Name")
+
+    return fakes, knowns
+
+
+def plot_objects(ax, objs, type_key, plot_kwargs, sort_on="mjd_mid"):
+    """Plots objects onto the given WCSAxes.
+
+    Objects are a table containing ``RA``, ``DEC``, `type_key` and
+    `sort_on` columns, grouped by the individual object. The object
+    positions are plotted as a scattered plot, with each object getting
+    a different visual formatting based on the object type value.
+    The `type_key` names a column that selects the visual formatting
+    via `plot_kwargs`. The plot keyword arguments must match the name
+    of the type of the object, f.e. "tno", "kbo", "asteroid" etc. or
+    the ``"*"`` literal to match any not-specified object type.
+    
+    The `plot_kwargs` is a dictionary with keys matching the desired
+    object type. Value of each key is a dictionary with appropriate
+    key-value pairs passed onto `ax.plot_coord`. Additionally, the
+    dictionary may contain keys ``start_marker`` and ``start_color``
+    keys that will be used to differently visualize the first position
+    of the object on the plot, to visualize the direction of motion.
+    By default this is a green triangle.
+
+    Parameters
+    ----------
+    ax : `WCSAxes`
+        Axis
+    objs : `Table`
+        Catalog of object positions, grouped by individual object.
+    type_key : `str`
+        Name of the column that contains the object type, f.e. ``tno``,
+        ``kbo``, ``asteroid`` etc.
+    plot_kwargs : `dict`
+        Dictionary containing the names of the object types, or ``*``,
+        and their formatting parameters. Optionally ``start_marker``
+        and ``start_color`` may be provided for each object class to
+        mark the first object position.
+    sort_on : `str`, optional
+        Name of the column on which to sort each object on. By default
+        ``mjd_mid``.
+
+    Returns
+    -------
+    ax : `WCSAxes`
+        Axis containing the artists.
+    """
+    plt_kwargs = plot_kwargs.copy()
+    legend_entries = []
+    for group in objs.groups:
+        if sort_on is not None:
+            group.sort(sort_on)
+                
+        kind = np.unique(group[type_key])
+        if len(kind) > 1:
+            raise ValueError(
+                "Object can only be classified into a single type. "
+                f"Got {kind} instead"
+            )
+
+        obj_type = group[type_key][0]
+        if obj_type not in plt_kwargs.keys():
+            if "*" in plt_kwargs.keys():
+                obj_type = "*"
+            else:
+                raise ValueError(
+                    f"Object type `{obj_type}` not found in the plot "
+                    f"arguments `{plt_kwargs.keys()}`"
+                )
+
+        sm = plt_kwargs[obj_type].pop("start_marker", "^")
+        sms = plt_kwargs[obj_type].pop("start_markersize", 1)
+        sc = plt_kwargs[obj_type].pop("start_color", "green")
+        pos = SkyCoord(group["RA"], group["DEC"], unit="degree",
+                       frame="icrs")
+
+        ax.plot_coord(pos, **plt_kwargs[obj_type])
+        ax.scatter_coord(pos[0], marker=sm, color=sc)
+
+    ax.legend(legend_entries)
+    return ax
+
+
+def plot_result(figure, res, fakes, knowns, wcs, obstimes):
+    """Plot a single result onto the `Figure`.
+
+    Four axes are plotted for each result, the likelihood and psi and
+    phi, the footprint of the WCS with positions of the result and
+    known objects within it, and two sets of postage stamp cutouts
+    centered on the results positions. One shares the normalization
+    range and the other does not.
+
+    Parameters
+    ----------
+    figure : `Figure`
+        Dataclass containing all the axes of the plot.
+    res : `Row`
+        Result.
+    fakes : `Table`
+        Catalog of all simulated objects positions. Must contain ``RA``
+        ``DEC``, ``mjd_mid`` and ``type`` columns. Must be grouped by
+         individual object.
+    knowns : `Table`
+        Catalog of all known real objects. Must contain ``RA``, ``DEC``
+        ``Type`` and ``mjd_mid`` columns. Must be grouped by individual
+        object.
+
+    Returns
+    -------
+    figure : `Figure`
+        Figure containing all the axes and their artists.
+    """
+    # Top Left plot
+    #    - Phi, Psi and Likelihood values
+    figure.psiphi.plot(res["psi_curve"], alpha=0.25, marker="o", label="psi")
+    figure.psiphi.plot(res["phi_curve"], alpha=0.25, marker="o", label="phi")
+    figure.psiphi.legend(loc="upper right")
+
+    figure.likelihood.plot(res["psi_curve"]/res["phi_curve"], marker="o", label="L", color="red")
+    figure.likelihood.set_title(
+        f"Likelihood: {res['likelihood']:.5}, obs_count: {res['obs_count']}, \n "
+        f"(x, y): ({res['x']}, {res['y']}), (vx, vy): ({res['vx']:.6}, {res['vy']:.6})"
+    )
+    figure.likelihood.legend(loc="upper left")
+
+    # Top right
+    #    - footprint of the CCD
+    #    - known fake objects
+    #    - known real objects
+    #    - trajectory of the result
+    # Order is important because of the z-level of the plotted artists
+    (blra, bldec), (tlra, tldec), (trra, trdec), (brra, brdec) = wcs.calc_footprint()
+    figure.sky.plot(
+        [blra, tlra, trra, brra, blra],
+        [bldec, tldec, trdec, brdec, bldec],
+        transform=figure.sky.get_transform("world"),
+        color="black", label="Footprint"
+    )
+
+    if len(fakes) > 0:
+        figure.sky = plot_objects(figure.sky, fakes, "type", KNOWN_OBJECTS_PLTSTYLE["fakes"])
+        
+    if len(knowns) > 0:
+        figure.sky = plot_objects(figure.sky, knowns, "Type", KNOWN_OBJECTS_PLTSTYLE["knowns"])
+
+    pos, pos_valid = result_to_skycoord(res, obstimes, res["obs_valid"], wcs)
+    figure.sky.plot_coord(pos, marker="o", markersize=1, linewidth=1, label="Search trj.", color="C0")        
+    if sum(pos_valid) > 0:
+        figure.sky.scatter_coord(pos[pos_valid], marker="+", alpha=0.25, label="Obs. valid", color="C0")
+    figure.sky.scatter_coord(pos[0], marker="^", color="green", label="Starting point")
+
+    # de-duplicate the axis entries
+    bb = {name : handle for handle, name in zip(*figure.sky.get_legend_handles_labels())}
+    handles = list(bb.values())
+    names = list(bb.keys())
+    figure.sky.legend(bb.values(), bb.keys(), loc="upper left", ncols=7)
+
+    # Bottom left
+    #    - individually scaled coadd stamps
+    stamp_types = ("coadd_mean", "coadd_median",
+                   "coadd_weighted", "coadd_sum")
+    for ax, kind in zip(figure.stamps.ravel(), stamp_types):
+        ax.imshow(res[kind], interpolation="none")
+        ax.set_title(kind)
+
+    # Bottom right
+    #    - postage stamps scaled to the mean stamp
+    ntype = stamp_types[0]
+    for ax, kind in zip(figure.normed_stamps.ravel(), stamp_types):
+        ax.imshow(res[kind], vmin=res[ntype].min(),
+                  vmax=res[ntype].max(), interpolation="none")
+        ax.set_title(kind)
+
+    return figure

--- a/src/kbmod_wf/utilities/logger_utilities.py
+++ b/src/kbmod_wf/utilities/logger_utilities.py
@@ -3,6 +3,15 @@ import traceback
 import logging
 from logging import config
 
+import os
+import re
+import glob
+
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.table import Table, vstack
+from astropy.time import Time, TimeDelta
+
 
 __all__ = [
     "LOGGING_CONFIG",
@@ -46,12 +55,8 @@ LOGGING_CONFIG = {
         },
     },
     "loggers": {
-        "parsl": {"level": "INFO"},
-        "task": {"level": "DEBUG", "handlers": ["stdout"], "propagate": False},
-        "task.create_manifest": {},
-        "task.ic_to_wu": {},
-        "task.reproject_wu": {},
-        "task.kbmod_search": {},
+        "parsl": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
+        "workflow": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
         "kbmod": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": False},
     },
 }
@@ -78,7 +83,8 @@ def get_configured_logger(logger_name, file_path=None):
 
 
 class ErrorLogger:
-    """Logs received errors before re-raising them.
+    """Context manager that logs received errors before re-raising
+    them.
 
     Parameters
     ----------
@@ -104,137 +110,70 @@ class ErrorLogger:
             return self.silence_errors
 
 
-
-
-import os
-import re
-import glob
-
-import numpy as np
-import matplotlib.pyplot as plt
-from astropy.table import Table, vstack
-from astropy.time import Time, TimeDelta
-
-
-class Timeline(plt.Line2D):
-    def __init__(self, linespec, name, name_pos="right", name_margin=None, name_fontsize=9,
-                 relative_to=None, units="hour", color="black", *args, **kwargs):
-        # We must marshal everything into datetime because time_support doesn't
-        # seem to be working. If we get a TimeDelta, marshal the values into
-        # the same units, and then strip the units into floats. Work strictly
-        # with datetime objects internally because those are the only ones
-        # Matplotlib plots natively
-        self.units = units
-        self.origin = relative_to
-
-        xvals, yvals = [], []
-        for line in linespec:
-            if self.origin is not None:
-                line["xdata"] = [(i-self.origin).to_value(units) for i in line["xdata"]]
-            else:
-                line["xdata"] = [i.datetime for i in line["xdata"]]
-            xvals.extend(line["xdata"])
-            yvals.extend(line["ydata"])
-
-        self.name_pos = name_pos
-        if isinstance(name_pos, Time):
-            self.name_pos = name_pos.datetime
-
-        txtx, txty = self._get_name_pos(name_pos, name_margin, xvals, yvals, relative_to)
-        self.text = plt.Text(txtx, txty, name, verticalalignment="center", fontsize=name_fontsize, color=color)
-        self.text.set_text(name)
-
-        # Leverage the math support of Time objects by casting this at the end
-        if isinstance(relative_to, Time):
-            self.origin = relative_to.datetime
-
-        self.linespec = linespec
-        # The line segments can now be used blindly regardless of whether
-        # we have a datetime objects, or floats
-        self.name_margin = name_margin
-        self.lines = []
-        for line in linespec:
-            name = line.pop("name")
-            self.lines.append(plt.Line2D(**line))
-
-        super().__init__(xvals, yvals, *args, color=color, **kwargs)
-
-    def _get_name_pos(self, name_pos, name_margin, xvals, yvals, relative_to):
-        txty = yvals[0]
-        if name_pos == "right":
-            txtx = xvals[-1]
-        elif name_pos == "left":
-            txtx = xvals[0]
-        else:
-            txtx = name_pos
-            self.txtx = name_pos
-
-        if relative_to is not None and not isinstance(txtx, float):
-            txtx = TimeDelta(txtx - relative_to)
-
-        if isinstance(txtx, TimeDelta):
-            txtx = txtx.to_value(self.units)
-
-        if isinstance(txtx, Time):
-            txtx = txtx.datetime
-
-        if name_margin is not None:
-            margin = TimeDelta(name_margin, format="sec")
-            if isinstance(txtx, float):
-                txtx = txtx + margin.to_value(self.units)
-            else:
-                txtx = txtx + margin.datetime
-
-        return txtx, txty
-
-    def set_figure(self, figure):
-        self.text.set_figure(figure)
-        [line.set_figure(figure) for line in self.lines]
-        super().set_figure(figure)
-
-    # Override the Axes property setter to set Axes on our children as well.
-    @plt.Line2D.axes.setter
-    def axes(self, new_axes):
-        self.text.axes = new_axes
-        self.text.set_clip_box(new_axes.bbox)
-        #self.text.set_clip_on(True)
-        # Call the superclass property setter.
-        for line in self.lines:
-            plt.Line2D.axes.fset(line, new_axes)
-            line.set_clip_box(new_axes.bbox)
-            line.set_clip_on(True)
-        plt.Line2D.axes.fset(self, new_axes)
-
-    def set_transform(self, transform):
-        self.text.set_transform(transform)
-        [l.set_transform(transform) for l in self.lines]
-        super().set_transform(transform)
-
-    def set_data(self, x, y):
-        super().set_data((x[0], x[-1]), (y[0], y[-1]))
-
-    def draw(self, renderer):
-        super().draw(renderer)
-        self.text.draw(renderer)
-        [line.draw(renderer) for line in self.lines]
-
-
-def parse_logfile(logfile):
-    stmt = re.compile(Log.fmt)
-    logs = {k: [] for k in stmt.groupindex}
-    with open(logfile) as of:
-        for line in of.readlines():
-            strmatch = re.search(stmt, line)
-            if strmatch is not None:
-                groups = strmatch.groupdict()
-                for k in logs:
-                    logs[k].append(groups[k])
-            else:
-                logs["msg"][-1] += line.strip()
-    return logs
-
-
 class Log:
+    """A log of a task.
+
+    Note that each Log can consist of multiple log files. For example
+    the complete log of a Task ``20210101_A`` can consist of multiple
+    steps called ``20210101_A_step1``, ``20210101_A_step2`` etc. thus
+    making the full Log of the event a union of every step.
+
+    Individual steps are parsed, extracting individual log entries and
+    context; assigning to each log step a success, error and completion
+    status.
+    A log is succesfull if all individual steps were succesfull.
+    A step is not completed if the log does not contain the expected
+    final log entry.
+    A step is marked with an error if the log produces a traceback or
+    an error report. A not completed log step does not indicate a error.
+    Not-completed, but not-errored, steps may be safely re-run.    
+    A log is a failure if all steps were not completed or any of the
+    steps has an error. A log may be safely re-run if no steps have an
+    error, but not all steps have completed.
+
+    Each step may contain repeated sequences of messages. When
+    running a task with Parsl, and it is pre-empted or it fails,
+    it can be resubmitted - leading to repeated collections of
+    messages.
+
+    To overwrite the default contextualization of the parsed logs
+    override the `_parse_single` method.
+    
+    Parameters
+    ----------
+    logfiles : `list`
+        List of log files belonging to the same Log event.
+    name : `str` or `None`, optional
+        Name of the log event, f.e. ``20210101_A``. When not provided
+        it will be determined as the longest shared common prefix of
+        each step.
+    stepnames : `list` or `None`, optional
+        Name of the each step, f.e. ``20210101_A_step1`` etc. When not
+        provided, it will be determined from the log itself.
+
+    Attributes
+    ----------
+    logfiles : `list`
+        Paths to log files.
+    name : `str`
+        Log group name
+    stepnames : `list[str]`
+        Names of steps involved in the log.
+    nsteps : `int`
+        Number of steps in the log.
+    started : `list`
+        List of step start times.
+    completed : `list`
+        List of step end times.
+    success : `list[bool]`
+        List of whether or not a step was determined to be succesfull.
+    error : `bool`
+        `True` when log contains a step with an error.
+    data : `Table`
+        Table of all log entries. Table is grouped by stepname and
+        step index.
+    """
+    
     fmt: str = r"\[(?P<process>[\w|-]*) (?P<thread>[\w|-]*) (?P<time>[\d|\-| |:|,]+) (?P<level>\w*) (?P<logger>.*)] (?P<msg>.*)$"
     """Log line format."""
 
@@ -288,6 +227,26 @@ class Log:
             self.data = self.data.group_by(["stepname", "stepidx"])
 
     def _parse_single(self, name, table):
+        """Contextualize each step in the log.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the log this step belongs to.
+        table : `Table`
+            Table of log entries of the step.
+
+        Returns
+        -------
+        started : `bool`
+            `True` if the step has any entries.
+        completed : `bool`
+            `True` if the step has the expected last message.
+        success: `bool`
+            `True` if the step has started, completed and has no errors.
+        stepname: `str`
+            Name of the step as deduced from the log entries.
+        """
         started, completed, success = False, False, False
         stepname = ""
         
@@ -338,36 +297,76 @@ class Log:
 
     @property
     def groups(self):
+        """Table groups."""
         return self.data.groups
 
     @property
     def start(self):
+        """Return the earliest timestep."""
         if len(self.data) > 0:
             return self.data[0]["time"]
         return None
 
     @property
     def end(self):
+        """Return the last timestep."""
         if len(self.data) > 0:
             return self.data[-1]["time"]
         return None
 
     def sort(self, *args, **kwargs):
+        """Sort the underlying table of logs.
+
+        See help(Table.sort) for more.
+        """
         self.data.sort(*args, **kwargs)
 
     def select(self, **kwargs):
+        """Select from the logs where column matches the value.
+
+        For example
+
+        ```python
+        Log.select(stepname="name", success=False)
+        ```
+        
+        will select from the log entries all those whose name is
+        ``name`` and success is `False`.
+
+        Parameters
+        ----------
+        **kwargs :
+            A list of keyword arguments and literal values on which the
+            table will be subselected on.
+        """
         mask = np.ones((len(self.data), ), dtype=bool)
         for arg, val in kwargs.items():
             mask = np.logical_and(mask, self.data[arg] == val)
         return self.data[mask]
 
     def group_by(self, *args, **kwargs):
+        """Group table entries by predicate.
+
+        See help(Table.group_by) for more.
+        """
         self.data = self.data.group_by(*args, **kwargs)
 
     def get_artist(self, y=0, relative_to=None, units="hour",  # Data params
                    marker="o",  linestyle="--", name_pos="right", name_margin=None,
                    **kwargs):
+        """Return the Log as a Timeline artist.
 
+        Parameters
+        -----------
+        y : `int`, optional
+        relative_to: `None`, optional
+        units : `str`, optional
+        marker : `str`, optional
+        linestyle : `str`, optional
+        name_pos : `str`, optional
+        name_margin : `None`, optional
+        **kwargs
+        """
         if len(self.data) == 0:
             return None
 
@@ -438,7 +437,59 @@ class Log:
         )
 
 
+def parse_logfile(logfile, fmt=Log.fmt):
+    """Parse a single log file given a string format.
+
+    The parsing is perfomed by regex using named groups.
+
+    Parameters
+    ----------
+    logfile : `str`
+        Path to the log file.
+    fmt : `str`
+        Regex matching string.
+
+    Returns
+    -------
+    parsed : `dict`
+        Dictionary containing parsed logs. Dictionary containing the
+        named groups as keys. Each key contains an list of values
+        extracted from each row of the log.
+    """
+    stmt = re.compile(fmt)
+    logs = {k: [] for k in stmt.groupindex}
+    with open(logfile) as of:
+        for line in of.readlines():
+            strmatch = re.search(stmt, line)
+            if strmatch is not None:
+                groups = strmatch.groupdict()
+                for k in logs:
+                    logs[k].append(groups[k])
+            else:
+                logs["msg"][-1] += line.strip()
+    return logs
+
+
 def parse_logdir(dirpath="."):
+    """Parse every file ending in ``log`` from the given directory.
+
+    This is not a generic function, logs are expected to be named as
+    ``{collname}[.step].log``. Log is expected to be parsable by the
+    `Log.log_fmt` regex string.
+
+    Parameters
+    ----------
+    dirpath : `str`
+        Path to the directory.
+
+    Returns
+    --------
+    logs : `list[dict]`
+        List of logs, each belonging to individual parsed log. Each
+        parsed log is a dict. Keys of the dict are the names of the
+        regex named groups. Values of the dict are lists containing the
+        regex parsed value of the group for that line.
+    """
     glob_stmt = os.path.join(dirpath, "*log")
     lognames = glob.glob(glob_stmt)
 
@@ -458,9 +509,235 @@ def parse_logdir(dirpath="."):
     return sorted(logs, key=lambda l: l.start)
 
 
+class Timeline(plt.Line2D):
+    """A Gantt timeline artist.
+
+    A Gantt timeline is a Matplotlib Line artist containing multiple
+    lines. Line segments represent sub-task durations of a single
+    Task, represented by the timeline.
+    
+    `Log`s represent themselves using the timeline matching to the
+    earliest and latest timestamp found in the logs. Each step in a
+    `Log` is a sub-length of the timeline with its own start and end
+    points.
+
+    A Timeline will be colored green if all the steps have started,
+    completed and raised no errors.
+    A Timeline segment will be colored yellow if a step has started,
+    but not completed, and has not raised an Error. 
+    A Timeline will be colored red if any of the steps have not
+    completed.
+
+    With each Timeline, a name is associated and plotted next to the
+    full timeline as a Text artist.
+    
+    Parameters
+    ----------
+    linespec : `list[dict]`
+        A list of dictionaries containing the data and the style of
+        a Timeline segment. The expected keys are ``name``, ``xdata``,
+        ``ydata``, but providing additional matplotlib accepted
+        keywords like ``color``, ``linestyle`` and ``marker`` is
+        allowed. The name is registered as the name of the Timeline
+        segment. The ``xdata`` and ``ydata`` are expected to be `Time`
+        objects.
+    name : `str`
+        Name of the Timeline.
+    name_pos: `str`, optional.
+        Position of the Timeline name, can be given as an `Time`,
+        `datetime` or strings ``right`` or ``left``. By default
+        all timeline names are plotted on the ``right`` of the timeline
+        line, at the time of the latest timestamp in the linespec.
+    name_margin : `float` or `None`, optional.
+        Offset from the given position, in seconds. By default is `None`.
+    name_fontsize : `float`, optional
+        Fontsize of the Timeline name.
+    relative_to : `Time`, `datetime` or `None`, optional
+        Express all timestamps in terms of elapsed time relative to an
+        origin. When `None` the full timestamp values are plotted instead
+        of an elapsed time.
+    units : `str`, optional
+        When ``relative_to`` is given, controls the units in which the
+        elapsed time is given in. Can be any string accepted by Astropy
+        `units`. Default: ``hours``
+    color : `str`, optional
+        Timeline color, this will color the underlying line and the
+        associated name text in the given color. Default: ``black``
+    *args, **kwargs :
+        Any additional, Matplotlib accepted, formatting options that
+        will be applied to the timeline line.
+    """
+    def __init__(self, linespec,
+                 name, name_pos="right", name_margin=None, name_fontsize=9,
+                 relative_to=None, units="hour",
+                 color="black", *args, **kwargs):
+        # We must marshal everything into datetime because time_support doesn't
+        # seem to be working. If we get a TimeDelta, marshal the values into
+        # the same units, and then strip the units into floats. Work strictly
+        # with datetime objects internally because those are the only ones
+        # Matplotlib plots natively
+        self.units = units
+        self.origin = relative_to
+
+        xvals, yvals = [], []
+        for line in linespec:
+            if self.origin is not None:
+                line["xdata"] = [(i-self.origin).to_value(units) for i in line["xdata"]]
+            else:
+                line["xdata"] = [i.datetime for i in line["xdata"]]
+            xvals.extend(line["xdata"])
+            yvals.extend(line["ydata"])
+
+        self.name_pos = name_pos
+        if isinstance(name_pos, Time):
+            self.name_pos = name_pos.datetime
+
+        txtx, txty = self._get_name_pos(name_pos, name_margin, xvals, yvals, relative_to)
+        self.text = plt.Text(txtx, txty, name, verticalalignment="center",
+                             fontsize=name_fontsize, name_color=color)
+        self.text.set_text(name)
+
+        # Leverage the math support of Time objects by casting this at the end
+        if isinstance(relative_to, Time):
+            self.origin = relative_to.datetime
+
+        self.linespec = linespec
+        # The line segments can now be used blindly regardless of whether
+        # we have a datetime objects, or floats
+        self.name_margin = name_margin
+        self.lines = []
+        for line in linespec:
+            name = line.pop("name")
+            self.lines.append(plt.Line2D(**line))
+
+        super().__init__(xvals, yvals, *args, color=color, **kwargs)
+
+    def _get_name_pos(self, name_pos, name_margin, xvals, yvals, relative_to):
+        """Resolve name position.
+
+        If the given position is the literal ``left`` or ``right`` find
+        the earliest and latest timestamp respectively, add the margin
+        and return the coordinate of the text.
+
+        If the given position is a `Time` or `Datetime` object, resolve
+        relative offset to origin, add margin and return position.
+        
+        Parameters
+        ----------
+        name_pos: `str`
+            Position of the Timeline name, can be given as an `Time`,
+            `datetime` or strings ``right`` or ``left``. By default
+            all timeline names are plotted on the ``right`` of the
+            timeline line, at the time of the latest timestamp in the
+            linespec.
+        name_margin : `float` or `None`
+            Offset from the given position, in seconds.
+            By default is `None`.
+        xvals : `list[Time]`
+            List of all timestamps on the timeline.
+        yvals : `list[int]`
+            Y-index of the timeline on the plot.
+        relative_to : `Time`, `datetime` or `None`, optional
+            Express all timestamps in terms of elapsed time relative
+            to an origin. When `None` the full timestamp values are
+            plotted instead of an elapsed time.        
+
+        Returns
+        -------
+        txtx : `datetime`
+            X-coordinate in datetime of the name text.
+        txty : `int`
+            Y-index of the text.
+        """
+        txty = yvals[0]
+        if name_pos == "right":
+            txtx = xvals[-1]
+        elif name_pos == "left":
+            txtx = xvals[0]
+        else:
+            txtx = name_pos
+            self.txtx = name_pos
+
+        if relative_to is not None and not isinstance(txtx, float):
+            txtx = TimeDelta(txtx - relative_to)
+
+        if isinstance(txtx, TimeDelta):
+            txtx = txtx.to_value(self.units)
+
+        if isinstance(txtx, Time):
+            txtx = txtx.datetime
+
+        if name_margin is not None:
+            margin = TimeDelta(name_margin, format="sec")
+            if isinstance(txtx, float):
+                txtx = txtx + margin.to_value(self.units)
+            else:
+                txtx = txtx + margin.datetime
+
+        return txtx, txty
+
+    ## Matplotlib API requirements. Set figure, axes, transform, data,
+    #  make values outside of the axes invisible and draw.
+    def set_figure(self, figure):
+        self.text.set_figure(figure)
+        [line.set_figure(figure) for line in self.lines]
+        super().set_figure(figure)
+
+    @plt.Line2D.axes.setter
+    def axes(self, new_axes):
+        self.text.axes = new_axes
+        self.text.set_clip_box(new_axes.bbox)
+        #self.text.set_clip_on(True)
+        # Call the superclass property setter.
+        for line in self.lines:
+            plt.Line2D.axes.fset(line, new_axes)
+            line.set_clip_box(new_axes.bbox)
+            line.set_clip_on(True)
+        plt.Line2D.axes.fset(self, new_axes)
+
+    def set_transform(self, transform):
+        self.text.set_transform(transform)
+        [l.set_transform(transform) for l in self.lines]
+        super().set_transform(transform)
+
+    def set_data(self, x, y):
+        super().set_data((x[0], x[-1]), (y[0], y[-1]))
+
+    def draw(self, renderer):
+        super().draw(renderer)
+        self.text.draw(renderer)
+        [line.draw(renderer) for line in self.lines]
+
+        
 def plot_campaign(ax, logs, relative_to_launch=True, units="hour",
          name_pos="right", name_margin=4,
          **kwargs):
+    """Plot a campaign, a collection of `Logs`, onthe given axis.
+
+    Parameters
+    ----------
+    ax : `Axes`
+        Matplotlib axis to contain the plot.
+    logs : `list[Log]`
+        Collection of logs which timelines will be plotted.
+    relative_to_launch : `bool`, optional
+        When `True` all of the timelines are expressed in ``units``
+        elapsed starting from the earliest timestamp.
+    units : `str`
+        Units in which the elapsed time is expressed in, by default
+        ``hours``. Can be any Astropy `units` accepted string.
+    name_pos : `str` or `Time`, optional
+        Position of the Timeline name. See `help(Timeline)` for more.
+    name_margin : `float` or None
+        Additional name margin. See `help(Timeline)` for more.
+    **kwargs :
+        Any additional kwargs are passed onto the `Log.get_artist` call.
+
+    Returns
+    -------
+    ax : `Axes`
+        Matplotlib axis containing the plot.
+    """
     # starts are sorted, but ends are not neccessarily in order
     workflow_start = logs[0].start
     workflow_end = max([log.end for log in logs])

--- a/src/kbmod_wf/utilities/logger_utilities.py
+++ b/src/kbmod_wf/utilities/logger_utilities.py
@@ -17,31 +17,31 @@ LOGGING_CONFIG = {
     },
     "handlers": {
         "stdout": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",
         },
         "stderr": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stderr",
         },
         "file": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.FileHandler",
-            "filename": "parsl.log",
+            "filename": "kbmod.log",
         },
     },
     "loggers": {
-        "task": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
+        "task": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": True},
         "task.create_manifest": {},
         "task.ic_to_wu": {},
         "task.reproject_wu": {},
-        "task.kbmod_search": {},
-        "kbmod": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
+        "task.kbmod_search": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": True},
+        "kbmod": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": False},
     },
 }
 """Default logging configuration for Parsl."""


### PR DESCRIPTION
Implements the DEEP Workflow used to analyze the single ccd single night search, but can be used to run on any set of image collections in a directory. 

Additional log parsing and visualization functionality is provided.

# Solution Description

## Workflow

Running the Workflow is a multi-step process which includes additional preparation and cleanup work that executes at the
submit location:
- Run prep
    - Load runtime config
    - find all files in `staging_directory` that match `ic_filename_pattern`
    - filter out unwanted files based on the name
- Run KBMOD Search 
- Summarize the workflow execution
    - Parse logs, create a list of failed and successful logs
    - Create a workflow Gantt chart

The config section that gives the directory, pattern and exclusion can look like:
```
[workflow]
staging_directory = "collections"
ic_filename_pattern = "*collection"
skip_ccds = ["002", "031", "061"]
```

The workflow writes to `logs`, `resampled_wus`, `results` and `plots` directories.        
Running a KBMOD search is a 3 step process:
- step 1 (executed on CPUs)
    - load ImageCollection
    - filter unwanted rows of data from it
        - for Rubin processed DEEP this should exclude all wcs_err > 1e-04
        - for Rubin processed DEEP probably should exclude zeropoint > 27 or similar 
        - this should probably reflect back onto the original ImageCollection, but it doesn't
        - so they're not implemented atm, because it causes confusion down the line
    - load SearchConfiguration
    - update search config values based on the IC metadata
        - currently the `n_obs` is the biggest discriminator for the data that is kept
        - we set the `n_obs` to `len(ic)//2` 
        - once the `len(ic)` gets below 50-60, this seems to be too strict of a requirement
        - then the `n_obs` is pinned to 15
    - materialize a WorkUnit
        - requires the Rubin Data Butler
    - resample a WorkUnit
        - targets the largest common footprint WCS
    - writes the WorkUnit to file
- step 2 (executed on GPUs)
    - loads the WorkUnit
    - runs KBMOD search
    - adds relevant metadata to the Results Table
        - this is not generalized solution
        - `wcs`, `mjd_mid` and `uuid` are guaranteed 
        - `visit` and `detector` don't exist for every `ImageCollection`
    - writes Results to file
- step 3 (executed on CPUs)
    - loads Results file
    - makes an analysis plot
    - this requires external resources, catalogs of fake and known objects
    - Known objects are SkyBot query results - so the plotting code is structured to work with that
    - this is not a general code though because user-made catalogs have no agreed upon standard

The config section for the step1 and postscript external resources can look like:

```
[apps.step1]
search_config_filepath = "earch_config.yaml"
butler_config_filepath = "/repo/root/butler.yaml"
n_workers = 8

[apps.postscript]
fake_object_catalog = "resources/fakes_detections_joined.minified.fits.bz2"
known_object_catalog = "resources/skybot_results_joined.minified.fits.bz2
```

## Logging 

Logs can be quite complicated. 

A single log file can have several starting and ending messages - because the jobs can be resubmitted. Often they are preempted with means they will have several initial messages and maybe one ending message.

A single task will output several log files - one per step. 

Each `Log` can consist of multiple log files. For example the complete log of a Task ``20210101_A`` can consist of multiple
steps called ``20210101_A_step1``, ``20210101_A_step2`` etc. thus making the full Log of the event a union of every step.

Individual steps are parsed, extracting individual log entries and context; assigning to each log step a success, error and completion status:
- a log is successful if all individual steps were successful.
- a step is not completed if the log does not contain the expected final log entry.
- a step is marked with an error if the log produces a traceback or an error report. A not completed log step does not indicate a error.
- a step that is marked not-completed, but not-errored, may be safely re-run
- a log is a failure if all steps were not completed or any of the steps has an error. A log may be safely re-run if no steps have an error, but not all steps have completed or not all steps have run (happens if the workflow times out and there were multiple retries).

Some functionality is pretty general - `parse_logfile`, the `Log` class and its `fmt` string, but contextualization depends heavily on the log content. This means much of the plotting colors etc. are affected too. To overwrite the default contextualization of the parsed logs override the `_parse_single` method. 

## Code Quality

The code is pretty shit, but at least it has documentation now and isn't duplicated across tasks. 

There will be some wrestling with the default values in the repo right now, but that is at least approachable compared to the draft PR.