### PR TITLE
Add USDF Configuration for Parsl Workflows

### DIFF
--- a/src/kbmod_wf/multi_night_workflow.py
+++ b/src/kbmod_wf/multi_night_workflow.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--env",
         type=str,
-        choices=["dev", "klone"],
+        choices=["dev", "klone", "usdf"],
         help="The environment to run the workflow in.",
     )
 

--- a/src/kbmod_wf/resource_configs/__init__.py
+++ b/src/kbmod_wf/resource_configs/__init__.py
@@ -1,4 +1,5 @@
 from .dev_configuration import dev_resource_config
 from .klone_configuration import klone_resource_config
+from .usdf_configuration import usdf_resource_config
 
-__all__ = ["dev_resource_config", "klone_resource_config"]
+__all__ = ["dev_resource_config", "klone_resource_config", "usdf_resource_config"]

--- a/src/kbmod_wf/resource_configs/usdf_configuration.py
+++ b/src/kbmod_wf/resource_configs/usdf_configuration.py
@@ -70,7 +70,7 @@ def usdf_resource_config():
                 label="sharded_reproject",
                 max_workers=1,
                 provider=SlurmProvider(
-                    partition="ampere",
+                    partition="milano",
                     account=account_name,
                     min_blocks=0,
                     max_blocks=2,
@@ -78,7 +78,7 @@ def usdf_resource_config():
                     parallelism=1,
                     nodes_per_block=1,
                     cores_per_node=32,
-                    mem_per_node=900,  # ~2-4 GB per core
+                    mem_per_node=512,  # ~2-4 GB per core
                     exclusive=False,
                     walltime=walltimes["sharded_reproject"],
                     scheduler_options='#SBATCH --export=ALL',  # Add other options as needed

--- a/src/kbmod_wf/resource_configs/usdf_configuration.py
+++ b/src/kbmod_wf/resource_configs/usdf_configuration.py
@@ -1,0 +1,137 @@
+import os
+import datetime
+from parsl import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import LocalProvider, SlurmProvider
+from parsl.utils import get_all_checkpoints
+
+walltimes = {
+    "compute_bigmem": "01:00:00",
+    "large_mem": "04:00:00",
+    "sharded_reproject": "04:00:00",
+    "gpu_max": "08:00:00",
+}
+
+base_path = '/sdf/data/rubin/user/wbeebe/parsl/workflow_output'
+
+account_name = 'rubin:commissioning'
+
+def usdf_resource_config():
+    return Config(
+        app_cache=True,
+        checkpoint_mode="task_exit",
+        checkpoint_files=get_all_checkpoints(
+            os.path.join(base_path, "kbmod/workflow/run_logs", datetime.date.today().isoformat())
+        ),
+        run_dir=os.path.join(base_path, "kbmod/workflow/run_logs", datetime.date.today().isoformat()),
+        retries=1,
+        executors=[
+            HighThroughputExecutor(
+                label="small_cpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="milano",
+                    account=account_name,
+                    min_blocks=0,
+                    max_blocks=4,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=1,  # perhaps should be 8???
+                    mem_per_node=256,  # In GB
+                    exclusive=False,
+                    walltime=walltimes["compute_bigmem"],
+                    scheduler_options='#SBATCH --export=ALL',  # Add other options as needed
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="large_mem",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="milano",
+                    account=account_name,
+                    min_blocks=0,
+                    max_blocks=2,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=32,
+                    mem_per_node=512,
+                    exclusive=False,
+                    walltime=walltimes["large_mem"],
+                    scheduler_options='#SBATCH --export=ALL',  # Add other options as needed
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="sharded_reproject",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ampere",
+                    account=account_name,
+                    min_blocks=0,
+                    max_blocks=2,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=32,
+                    mem_per_node=900,  # ~2-4 GB per core
+                    exclusive=False,
+                    walltime=walltimes["sharded_reproject"],
+                    scheduler_options='#SBATCH --export=ALL',  # Add other options as needed
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="ada",
+                    account=account_name,
+                    min_blocks=0,
+                    max_blocks=2,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=512,  # In GB
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1\n#SBATCH --export=ALL",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="large_gpu",
+                max_workers=1,
+                provider=SlurmProvider(
+                    partition="turing", # TODO verify this
+                    account=account_name,
+                    min_blocks=0,
+                    max_blocks=2,
+                    init_blocks=0,
+                    parallelism=1,
+                    nodes_per_block=1,
+                    cores_per_node=2,  # perhaps should be 8???
+                    mem_per_node=512,  # In GB
+                    exclusive=False,
+                    walltime=walltimes["gpu_max"],
+                    # Command to run before starting worker - i.e. conda activate <special_env>
+                    worker_init="",
+                    scheduler_options="#SBATCH --gpus=1\n#SBATCH --export=ALL",
+                ),
+            ),
+            HighThroughputExecutor(
+                label="local_thread",
+                provider=LocalProvider(
+                    init_blocks=0,
+                    max_blocks=1,
+                ),
+            ),
+        ],
+    )

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -128,7 +128,8 @@ class WUReprojector:
 
         # Use the global WCS that was specified from the ImageCollection.
         ic = ImageCollection.read(self.ic_filepath, format="ascii.ecsv")
-        common_wcs = WCS(ic["global_wcs"][0])
+        common_wcs = WCS(ic.data['global_wcs'][0])
+        common_wcs.pixel_shape = (ic.data['global_wcs_pixel_shape_0'][0], ic.data['global_wcs_pixel_shape_1'][0])
 
         resampled_wu = reprojection.reproject_work_unit(
             wu,

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -96,12 +96,12 @@ class WUReprojector:
         )
 
         #! This method to get image dimensions won't hold if the images are different sizes.
-        image_height, image_width = wu._per_image_wcs[0].array_shape
+        image_height, image_width = wu.get_wcs(0).array_shape
 
         # Find the EBD (estimated barycentric distance) WCS for each image
         last_time = time.time()
         ebd_per_image_wcs, geocentric_dists = transform_wcses_to_ebd(
-            wu._per_image_wcs,
+            [wu.get_wcs(i) for i in range(len(wu))],
             image_width,
             image_height,
             self.guess_dist, # heliocentric guess distance in AU
@@ -113,14 +113,9 @@ class WUReprojector:
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to transform WCS objects to EBD..")
 
-        if len(wu._per_image_wcs) != len(ebd_per_image_wcs):
-            raise ValueError(
-                f"Number of barycentric WCS objects ({len(ebd_per_image_wcs)}) does not match the original number of images ({len(wu._per_image_wcs)})."
-            )
-
-        wu._per_image_ebd_wcs = ebd_per_image_wcs
+        wu.org_img_meta["ebd_wcs"] = ebd_per_image_wcs
         wu.heliocentric_distance = self.guess_dist
-        wu.geocentric_distances = geocentric_dists
+        wu.org_img_meta["geocentric_distance"] = geocentric_dists
 
         # Reproject to a common WCS using the WCS for our patch
         self.logger.debug(f"Reprojecting WorkUnit with {self.n_workers} workers...")
@@ -128,6 +123,8 @@ class WUReprojector:
 
         # Use the global WCS that was specified from the ImageCollection.
         ic = ImageCollection.read(self.ic_filepath, format="ascii.ecsv")
+
+        # Pick the first global WCS and pixel shape from the ImageCollection
         common_wcs = WCS(ic.data['global_wcs'][0])
         common_wcs.pixel_shape = (ic.data['global_wcs_pixel_shape_0'][0], ic.data['global_wcs_pixel_shape_1'][0])
 

--- a/src/kbmod_wf/utilities/configuration_utilities.py
+++ b/src/kbmod_wf/utilities/configuration_utilities.py
@@ -5,14 +5,14 @@ from typing import Literal
 from kbmod_wf.resource_configs import *
 
 
-def get_resource_config(env: Literal["dev", "klone"] | None = None):
+def get_resource_config(env: Literal["dev", "klone", "usdf"] | None = None):
     """A naive attempt to return a reasonable configuration using platform.system.
     This will likely be insufficient in a very short amount of time, but this
     is meant to be a first step.
 
     Parameters
     ----------
-    env : Literal["dev", "klone"] | None, optional
+    env : Literal["dev", "klone", "usdf"] | None, optional
         The common name used to retrieve the given configuration, by default None.
         If none, the configuration will be determined by the platform.system().
 
@@ -38,6 +38,8 @@ def get_resource_config(env: Literal["dev", "klone"] | None = None):
         config = dev_resource_config()
     elif env == "klone":
         config = klone_resource_config()
+    elif env == "usdf":
+        config = usdf_resource_config()
     else:
         raise ValueError(f"Unknown environment: {env}")
 

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--env",
         type=str,
-        choices=["dev", "klone"],
+        choices=["dev", "klone", "usdf"],
         help="The environment to run the workflow in.",
     )
 


### PR DESCRIPTION
Here, we add an updated workflow for running with data on USDF. This is primarily done by adding a new configuration file, but note that to the SLURM provider scheduler options we add

```scheduler_options='#SBATCH --export=ALL',  # Add other options as needed```

which exports all environment variables from the caller. This ensures that we are inheriting the environment needed to be authenticated by the embargoed Rubin butler.

There are also some minor changes to use the updated WorkUnit interface, and utilizing the `global_wcs_pixel_shape_0` and `global_wcs_pixel_shape_1` columns in the ImageCollection to ensure that the NAXIS values are saved in our serialized common WCS.