### PR TITLE
Add Option To Clean Up Work Units After KBMOD Search Stage

### DIFF
--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -92,16 +92,17 @@ class KBMODSearcher:
 
         self.logger.info(f"Writing results to output file: {self.result_filepath}")
         res.write_table(self.result_filepath)
-
         self.logger.info("Results written to file")
+    
         if self.cleanup_wu:
             self.logger.info(f"Cleaning up sharded WorkUnit {self.input_wu_filepath} with {len(wu)}")
-            # Delete the head WorkUnit file at self.input_wu_filepath
+            # Delete the head filefor the WorkUnit
             try:
                 os.remove(self.input_wu_filepath)
             except Exception as e:
                 self.logger.warning(f"Failed to remove {self.input_wu_filepath}: {e}")
-            # Delete the shards for this WorkUnit
+
+            # Delete the individual shards for this WorkUnit, one existing for each image.
             for i in range(len(wu)):
                 shard_path = os.path.join(directory_containing_shards, f"{i}_{wu_filename}")
                 try:


### PR DESCRIPTION
Currently the `src/kbmod_wf/multi_night_workflow.py` saved sharded reprojected WorkUnits along with the KBMOD results. Here we add a `cleanup_wu` flag (default=false) which can be added to the `[apps.kbmod_search]` section of your parsl runtime config as follows

```
[apps.kbmod_search]
# Delete the reprojected WorkUnit (including all files) after we've successfully written a results file
cleanup_wu = true 

# The path to the KBMOD search config file
search_config_filepath =  "path/to/search/config"

helio_guess_dists = [39.0] # Guess distances used

```
Given limited storage, this allows us to do large scale runs where we do not save the WorkUnits. 

