### PR TITLE
Remove date from Parsl workflow run directory

### DIFF
--- a/src/kbmod_wf/resource_configs/usdf_configuration.py
+++ b/src/kbmod_wf/resource_configs/usdf_configuration.py
@@ -22,9 +22,9 @@ def usdf_resource_config():
         app_cache=True,
         checkpoint_mode="task_exit",
         checkpoint_files=get_all_checkpoints(
-            os.path.join(base_path, "kbmod/workflow/run_logs", datetime.date.today().isoformat())
+            os.path.join(base_path, "kbmod/workflow/run_logs")
         ),
-        run_dir=os.path.join(base_path, "kbmod/workflow/run_logs", datetime.date.today().isoformat()),
+        run_dir=os.path.join(base_path, "kbmod/workflow/run_logs"),
         retries=1,
         executors=[
             HighThroughputExecutor(


### PR DESCRIPTION
Currently, when kicking off a parsl workflow, we use the current date in creating the parsl run directory.

However this prevents parsl from being able to find checkpoints when resuming runs from a previous date. So we simply remove the date from the run directory path.