### PR TITLE
One node to rule them all

### DIFF
--- a/scripts/generic_parent_parsl_sbatch.sh
+++ b/scripts/generic_parent_parsl_sbatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=parslParent
-#SBATCH --time=48:00:00
+#SBATCH --time=72:00:00
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=16G

--- a/scripts/generic_search_config.yaml
+++ b/scripts/generic_search_config.yaml
@@ -10,6 +10,7 @@ do_clustering: true
 do_mask: true
 do_stamp_filter: false
 encode_num_bytes: -1
+gpu_filter: true
 generator_config:
   angle_units: degree
   angles:

--- a/scripts/gpu_worker_launcher.sh
+++ b/scripts/gpu_worker_launcher.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This will be called by each Parsl worker
+
+# Choose GPU based on slot/index in the host
+WORKER_ID=$1
+export CUDA_VISIBLE_DEVICES=$WORKER_ID
+
+# Print for debugging
+echo "Launching worker $WORKER_ID on GPU $CUDA_VISIBLE_DEVICES"
+
+# Shift args and exec actual worker
+shift
+exec "$@"

--- a/scripts/parsl_configurator.py
+++ b/scripts/parsl_configurator.py
@@ -1,9 +1,29 @@
 # 4/21/2025 COC
 
 import os
-import inspect 
-import os 
+import inspect
+import os
+import shutil
+import glob
+
 script_directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+
+def get_reflex_distance(basedir, mode="collection"):
+    """Determine reflex distance, either by filename or by .collection content. 5/5/2025 COC"""
+    reflex_distance = None
+    first_ic_path = glob.glob(f"{basedir}/*.collection")[0]
+    if mode == "collection":
+        print(f"Determining reflex distances via first row of first collection in {basedir}...")
+        import kbmod
+        ic = kbmod.ImageCollection.read(first_ic_path)
+        reflex_distance = ic["helio_guess_dist"][0]
+    else:
+        print("Using default mode for get_reflex_distance: collection name")
+        reflex_distance = os.path.basename(first_ic_path).split("_")[1]
+    reflex_distance = float(reflex_distance)
+    print(f"Using reflex_distance {reflex_distance}")
+    return reflex_distance
+
 
 def make_toml_file(basedir, generic_toml_path, site_name="Rubin", disable_cleanup=False, nworkers=32, repo_path="/repo/main", reflex_distances=None):
     #
@@ -47,19 +67,20 @@ def make_sbatch_file(generic_sbatch_file, basedir, comment=None):
     """
     outfile = f"{basedir}/parent_parsl_sbatch.sh"
     tomlfile = f"{basedir}/runtime_config.toml"
-    
+    #
     lookup_dict = {}
     lookup_dict["____basedir____"] = basedir
     lookup_dict["____tomlfile____"] = tomlfile
-    
+    #
     if comment == None:
         lookup_dict["____comment____"] = os.path.basename(basedir)
     else:
         lookup_dict["____comment____"] = comment
-    
+    #
     with open(outfile, "w") as f:
         with open(generic_sbatch_file, "r") as g:
             for line in g:
+                line = line.rstrip("\n")
 #               if line.startswith("#") or len(line) == 0:
 #                   print(line, file=f)
 #                   continue
@@ -80,6 +101,7 @@ def make_yaml_file(generic_yaml_file, basedir):
     with open(generic_yaml_file, 'r') as g:
         with open(yaml_outfile, 'w') as f:
             for line in g:
+                line = line.rstrip("\n")
                 print(line, file=f)
     print(f'Wrote {yaml_outfile} to disk.')
     return yaml_outfile
@@ -97,19 +119,26 @@ if __name__ == '__main__':
     parser.add_argument('--generic-toml-path', dest='generic_toml_path', help='Path to a special generic TOML file. Default: ~/generic_runtime_config.toml', type=str, default=f"{script_directory}/generic_runtime_config.toml")
     parser.add_argument('--generic-sbatch-path', dest='generic_sbatch_path', help='Path to a special generic sbatch file. Default: ~/generic_parent_parsl_sbatch.sh', type=str, default=f"{script_directory}/generic_parent_parsl_sbatch.sh")
     parser.add_argument('--generic-yaml-path', dest='generic_yaml_path', help='Path to a special generic kbmod search config yaml file. Default: ~/generic_search_config.yaml', type=str, default=f"{script_directory}/generic_search_config.yaml")
-    
     #
     args = parser.parse_args()
     #
     # TODO add checks for input files here
     #
+    reflex_distances = args.reflex_distances
+    if reflex_distances == None or reflex_distances == []:
+        reflex_distances = [get_reflex_distance(basedir=args.basedir)]
     make_toml_file(basedir=args.basedir, 
                 generic_toml_path=args.generic_toml_path, 
                 site_name=args.site_name, 
                 disable_cleanup=args.disable_cleanup, 
                 nworkers=args.nworkers, 
                 repo_path=args.repo_path, 
-                reflex_distances=args.reflex_distances
+                reflex_distances=reflex_distances
             )
     make_sbatch_file(generic_sbatch_file=args.generic_sbatch_path, basedir=args.basedir)
     make_yaml_file(generic_yaml_file=args.generic_yaml_path, basedir=args.basedir)
+    #
+    # Copy the GPU Worker script
+    shutil.copy(os.path.join(script_directory, "gpu_worker_launcher.sh"), args.basedir)
+    #
+    print(f"Finished!")

--- a/src/kbmod_wf/resource_configs/usdf_configuration.py
+++ b/src/kbmod_wf/resource_configs/usdf_configuration.py
@@ -5,8 +5,8 @@
 # Ada - L40S - 46 Gb GPU - ~512 Gb max RAM
 
 #
-# removed max_workers from executors 4/23/2025 COC
 #
+# trying 10X10s so lowering memory by 50% to 240 on reproejct phase
 
 import os
 import datetime
@@ -17,29 +17,39 @@ from parsl.utils import get_all_checkpoints
 from parsl.monitoring.monitoring import MonitoringHub # COC
 from parsl.addresses import address_by_hostname # COC
 import logging # COC
-
+import numpy as np
 import platform
 
 nodename_map = {"sdfada":"ada", "sdfampere":"ampere", "sdfroma":"roma", "sdfmilano":"milano"}
-max_ram_dict = {"ada":70, # 351 Gb total, with 5 GPUs total on the one node, leaves 70 Gb per task
-		"ampere":220, # 896 per each of the two nodes we can access, each with 4 GPUs
-		"roma":480,
-		"milano":480
+
+slurm_cmd_timeout = 60 # default is 10 and that is timing out for sacct -X 5/1/2025 COC
+
+max_ram_dict = {"ada":350, # 351 Gb total, with 5 GPUs total on the one node, leaves 70 Gb per task
+		"ampere":952, # 896 per each of the two nodes we can access, each with 4 GPUs
+		"roma":140, # 240 to 140
+		"milano":140 # 240 to 140
 }
-max_block_dict = {"ada":5, "ampere":8}
+max_block_dict = {"ada":1, "ampere":2}
+gpus_per_node_dict = {"ada":5, "ampere":4}
+max_nodes_dict = {"ada":1, "ampere":2}
+cpus_per_node_dict = {"ada":30, "ampere":112} # {"ada":6, "ampere":28} # ada cap is 36, ampere ≥100
+cores_per_worker_dict = {"ada":6, "ampere":28}
+monitor_port_dict = {"ada":55056, "ampere":55066}
+
+
 gpu_partition = "ampere"
-cpu_partition = "milano"
+cpus_for_gpus_dict = {"ampere":"roma", "ada":"milano"}
+cpu_partition = cpus_for_gpus_dict[gpu_partition]
+
 
 if "GPUNODE" in os.environ:
-	gpu_partition = os.environ["GPUNODE"].lower()
-	print(f"Set gpu_partition to {gpu_partition} via environment variable GPUNODE.")
+    gpu_partition = os.environ["GPUNODE"].lower()
+    print(f"Set gpu_partition to {gpu_partition} via environment variable GPUNODE.")
 
 
 walltimes = {
-    "compute_bigmem": "01:00:00",
-    "large_mem": "04:00:00",
     "sharded_reproject": "04:00:00",
-    "gpu_max": "08:00:00",
+    "gpu": "12:00:00",
 }
 
 base_path = f"{os.environ['HOME']}/rubin-user/parsl/workflow_output"
@@ -58,51 +68,9 @@ def usdf_resource_config():
         retries=1,
         executors=[
             HighThroughputExecutor(
-                label="small_cpu",
-                # max_workers=1,
-		max_workers_per_node=1,
-                provider=SlurmProvider(
-                    partition=cpu_partition,
-                    account=account_name,
-                    min_blocks=0,
-                    max_blocks=64,
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    cores_per_node=1,  # perhaps should be 8???
-                    mem_per_node=256,  # In GB; milano, roma have a ~480 Gb cap 4/16/2025 COC
-                    exclusive=False,
-                    walltime=walltimes["compute_bigmem"],
-                    scheduler_options="#SBATCH --export=ALL",  # Add other options as needed
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="large_mem",
-                # max_workers=1,
-		max_workers_per_node=1,
-                provider=SlurmProvider(
-                    partition="roma", # or ada?; note: milano, roma have a ~480 Gb cap 4/16/2025 COC
-                    account=account_name,
-                    min_blocks=0,
-                    max_blocks=20, # 12 to 20 4/16/2025 COC
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    cores_per_node=32,
-                    mem_per_node=max_ram_dict["roma"],
-                    exclusive=False,
-                    walltime=walltimes["large_mem"],
-                    scheduler_options="#SBATCH --export=ALL",  # Add other options as needed
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="",
-                ),
-            ),
-            HighThroughputExecutor(
                 label="sharded_reproject",
                 # max_workers=1,
-		max_workers_per_node=1,
+                max_workers_per_node=1,
                 provider=SlurmProvider(
                     partition=cpu_partition, # or ada?; see resource notes at top
                     account=account_name,
@@ -118,48 +86,40 @@ def usdf_resource_config():
                     scheduler_options="#SBATCH --export=ALL",  # Add other options as needed
                     # Command to run before starting worker - i.e. conda activate <special_env>
                     worker_init="env | grep SLURM",
+                    cmd_timeout=slurm_cmd_timeout,
                 ),
             ),
             HighThroughputExecutor(
                 label="gpu",
-                # max_workers=1,
-		max_workers_per_node=1,
+                max_workers_per_node=gpus_per_node_dict[gpu_partition], # was 1
+                cores_per_worker=cores_per_worker_dict[gpu_partition],
+                mem_per_worker=int(np.floor(max_ram_dict[gpu_partition]/gpus_per_node_dict[gpu_partition])),
                 provider=SlurmProvider(
                     partition=gpu_partition, # or ada
                     account=account_name,
-                    min_blocks=0,
+                    min_blocks=max_nodes_dict[gpu_partition], # was 0
+                    init_blocks=max_nodes_dict[gpu_partition], # added 4/29/2025 COC
                     max_blocks=max_block_dict[gpu_partition], # 8 to 24 4/16/2025 COC to 12 4/20/2025 COC to 8 4/22/2025 COC
-                    init_blocks=0,
                     parallelism=1,
                     nodes_per_block=1,
-                    cores_per_node=4,  # perhaps should be 8???
+                    cores_per_node=cpus_per_node_dict[gpu_partition],
                     mem_per_node=max_ram_dict[gpu_partition],  # In GB; 512 OOMs with 20X20s 4/16/2025 COC
-                    exclusive=False,
-                    walltime=walltimes["gpu_max"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="hostname;hostnamectl;nvidia-smi;env | grep SLURM",
-                    scheduler_options="#SBATCH --gpus=1\n#SBATCH --export=ALL",
-                ),
-            ),
-            HighThroughputExecutor(
-                label="large_gpu",
-                # max_workers=1,
-		max_workers_per_node=1,
-                provider=SlurmProvider(
-                    partition=gpu_partition,  # or ada; was turing, but we do not have access
-                    account=account_name,
-                    min_blocks=0,
-                    max_blocks=max_block_dict[gpu_partition], # 8 to 24 4/16/2025 COC to 12 4/20/2025 to 8 4/25/2025 COC
-                    init_blocks=0,
-                    parallelism=1,
-                    nodes_per_block=1,
-                    cores_per_node=4,  # perhaps should be 8???
-                    mem_per_node=max_ram_dict[gpu_partition],  # In GB; 512G OOM with 20X20 4/16/2025 COC
-                    exclusive=False,
-                    walltime=walltimes["gpu_max"],
-                    # Command to run before starting worker - i.e. conda activate <special_env>
-                    worker_init="hostname;hostnamectl;nvidia-smi;env | grep SLURM",
-                    scheduler_options="#SBATCH --gpus=1\n#SBATCH --export=ALL",
+ #                   exclusive=False, # disabled
+                    walltime=walltimes["gpu"],
+                    cmd_timeout=slurm_cmd_timeout,
+                    worker_init="""
+export CUDA_VISIBLE_DEVICES=$((${PARSL_WORKER_RANK:-0} % 4))
+echo Assigned GPU $CUDA_VISIBLE_DEVICES to worker $PARSL_WORKER_RANK
+hostname
+hostnamectl
+nvidia-smi
+env
+""",
+                    scheduler_options=f"""
+#SBATCH --gres=gpu:{gpus_per_node_dict[gpu_partition]}
+#SBATCH --exclusive
+""",
+#"#SBATCH --gpus=1\n#SBATCH --export=ALL",
                 ),
             ),
             HighThroughputExecutor(
@@ -172,8 +132,9 @@ def usdf_resource_config():
         ],
 	monitoring=MonitoringHub(
        		hub_address=address_by_hostname(),
-       		hub_port=55055,
+       		hub_port=monitor_port_dict[gpu_partition],
        		monitoring_debug=True,
        		resource_monitoring_interval=10,
    	),
     )
+    

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -27,6 +27,9 @@ def kbmod_search(
     str
         The fully resolved filepath of the results file.
     """
+    worker_rank = os.environ["PARSL_WORKER_RANK"]
+    os.environ["CUDA_VISIBLE_DEVICES"] = worker_rank
+    print(f"Set worker_rank to {worker_rank}")
     kbmod_searcher = KBMODSearcher(
         wu_filepath=wu_filepath,
         result_filepath=result_filepath,

--- a/src/kbmod_wf/utilities/logger_utilities.py
+++ b/src/kbmod_wf/utilities/logger_utilities.py
@@ -17,31 +17,31 @@ LOGGING_CONFIG = {
     },
     "handlers": {
         "stdout": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",
         },
         "stderr": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stderr",
         },
         "file": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "standard",
             "class": "logging.FileHandler",
             "filename": "parsl.log",
         },
     },
     "loggers": {
-        "task": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
+        "task": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": False},
         "task.create_manifest": {},
         "task.ic_to_wu": {},
         "task.reproject_wu": {},
         "task.kbmod_search": {},
-        "kbmod": {"level": "INFO", "handlers": ["file", "stdout"], "propagate": False},
+        "kbmod": {"level": "DEBUG", "handlers": ["file", "stdout"], "propagate": False},
     },
 }
 """Default logging configuration for Parsl."""


### PR DESCRIPTION
Added a gpu worker shells script. For the whole-node approach, we take one node and generate as many workers as there are GPUs.

- Reenabled GPU-based sigma-g filtering
- Increased parent Parsl worker to 3 days
- Fixed extra whitespace (empty lines) in generic file copying in the Parsl configurator
- Added method to derive reflex-correction distance via collection or filename in configurator
- Vast changes to maximum memory, number of nodes/blocks etc. in usdf resource configuration
- Cleaned up (removed) unusued executors for usdf configuration
- kbmod task logger now set to a lower level to report more in the logs