### PR TITLE
Add flag to disorder/fuzz the obstimes of a WorkUnit

### DIFF
--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -54,6 +54,10 @@ class KBMODSearcher:
         self.cleanup_wu = self.runtime_config.get("cleanup_wu", False)
         self.results_directory = os.path.dirname(self.result_filepath)
 
+        # Whether or not to randomize timestamp ordering to create bad searches
+        # Useful for testing and ML training purposes.
+        self.disordered_search = self.runtime_config.get("disordered_search", False)
+
     def run_search(self):
         # Check that KBMOD has access to a GPU before starting the search.
         if not kbmod.search.HAS_GPU:
@@ -74,6 +78,9 @@ class KBMODSearcher:
 
         config = wu.config
 
+        if self.disordered_search:
+            wu.disorder_obstimes()
+
         # Modify the work unit results to be what is specified in command line args
         base_filename, _ = os.path.splitext(os.path.basename(self.result_filepath))
         input_parameters = {
@@ -93,7 +100,7 @@ class KBMODSearcher:
         self.logger.info(f"Writing results to output file: {self.result_filepath}")
         res.write_table(self.result_filepath)
         self.logger.info("Results written to file")
-    
+
         if self.cleanup_wu:
             self.logger.info(f"Cleaning up sharded WorkUnit {self.input_wu_filepath} with {len(wu)}")
             # Delete the head filefor the WorkUnit


### PR DESCRIPTION
DRAFT until https://github.com/dirac-institute/kbmod/pull/972 is submitted

Adds a `disordered_search` boolean flag which would gate the disordering/fuzzing of WorkUnit obstimes proposed in https://github.com/dirac-institute/kbmod/pull/972

This would be a flag added to the pyproject.toml as part of the search stage. We load in an existing reflex-corrected WorkUnit and then perform the "disordering" of obstimes