### PR TITLE
Save results files as parquet rather than ecsv

### DIFF
--- a/src/kbmod_wf/multi_night_workflow.py
+++ b/src/kbmod_wf/multi_night_workflow.py
@@ -112,7 +112,7 @@ def workflow_runner(env=None, runtime_config={}):
             search_futures.append(
                 kbmod_search(
                     inputs=[f],
-                    outputs=[File(repro_wu_filenames[i] + ".search.ecsv")],
+                    outputs=[File(repro_wu_filenames[i] + ".search.parquet")],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )

--- a/src/kbmod_wf/single_chip_workflow.py
+++ b/src/kbmod_wf/single_chip_workflow.py
@@ -117,7 +117,7 @@ def workflow_runner(env=None, runtime_config={}):
             search_futures.append(
                 kbmod_search(
                     inputs=[f.result()],
-                    outputs=[File(f.result().filepath + ".search.ecsv")],
+                    outputs=[File(f.result().filepath + ".search.parquet")],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )

--- a/src/kbmod_wf/tno_workflow.py
+++ b/src/kbmod_wf/tno_workflow.py
@@ -101,7 +101,7 @@ def workflow_runner(env=None, runtime_config={}):
             search_futures.append(
                 kbmod_search(
                     inputs=[f.result()],
-                    outputs=[File(f.result().filepath + ".search.ecsv")],
+                    outputs=[File(f.result().filepath + ".search.parquet")],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )

--- a/src/kbmod_wf/workflow.py
+++ b/src/kbmod_wf/workflow.py
@@ -97,7 +97,7 @@ def workflow_runner(env=None, runtime_config={}):
             search_futures.append(
                 kbmod_search(
                     inputs=[f.result()],
-                    outputs=[File(f.result().filepath + ".search.ecsv")],
+                    outputs=[File(f.result().filepath + ".search.parquet")],
                     runtime_config=app_configs.get("kbmod_search", {}),
                     logging_file=logging_file,
                 )

--- a/src/kbmod_wf/workflow_tasks/kbmod_search.py
+++ b/src/kbmod_wf/workflow_tasks/kbmod_search.py
@@ -36,7 +36,7 @@ def kbmod_search(inputs=(), outputs=(), runtime_config={}, logging_file=None):
     with ErrorLogger(logger):
         kbmod_search(
             wu_filepath=inputs[0].filepath,
-            result_filepath=inputs[0].filepath + ".search.ecsv",
+            result_filepath=inputs[0].filepath + ".search.parquet",
             runtime_config=runtime_config,
             logger=logger,
         )


### PR DESCRIPTION
KBMOD uses the file extension to determine what format to serialize resutls files in. Here, update the workflow to always use parquet rather than ecsv.  

This seems to produce around 75% memory savings and substantial savings in read and write times.

Note that not all of these paths are used by the current workflow and this is a simple find-replace.
