### PR TITLE
Have EBD resampling use 100 points instead of 10

### DIFF
--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_from_uris.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_from_uris.py
@@ -127,7 +127,7 @@ class WUReprojector:
             self.guess_dist,
             Time(wu.get_all_obstimes(), format="mjd"),
             self.point_on_earth,
-            npoints=10,
+            npoints=100,
             seed=None,
         )
         elapsed = round(time.time() - last_time, 1)

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -107,7 +107,7 @@ class WUReprojector:
             self.guess_dist,  # heliocentric guess distance in AU
             Time(wu.get_all_obstimes(), format="mjd"),
             self.point_on_earth,
-            npoints=10,
+            npoints=100,
             seed=None,
         )
         elapsed = round(time.time() - last_time, 1)


### PR DESCRIPTION
When resampling WCSes to EBD / SSB space, we want to use 100 random points in addition to the chip corner. This was recommended as the most frequently tested value by @maxwest-uw. Previously we were using 10 on the DEEP processing for undocumented reasons.