### PR TITLE
Change default observation site from 'ctio' to 'Rubin'

### DIFF
--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -78,7 +78,7 @@ class WUReprojector:
         # Default to 8 workers if not in the config. Value must be 0<num workers<65.
         self.n_workers = max(1, min(self.runtime_config.get("n_workers", 8), 64))
 
-        self.point_on_earth = EarthLocation.of_site(self.runtime_config.get("observation_site", "ctio"))
+        self.point_on_earth = EarthLocation.of_site(self.runtime_config.get("observation_site", "Rubin"))
 
     def reproject_workunit(self):
         last_time = time.time()


### PR DESCRIPTION
Change our default observation site from 'ctio' to 'Rubin'  for when no observation site is provided in the config