### PR TITLE
Support Synthetic Object Injection

### DIFF
--- a/example_runtime_config.toml
+++ b/example_runtime_config.toml
@@ -27,6 +27,20 @@ butler_config_filepath = "/gscratch/dirac/DEEP/repo/butler.yaml"
 # Remove a previously created WU file if it exists
 overwrite = false
 
+# Injection configuration section
+# Supports two modes: Generative (random catalog) or Pre-Computed (user-supplied catalog)
+[apps.ic_to_wu.injection]
+# Number of synthetic objects to inject per ImageCollection (Generative mode)
+n_objs_per_ic = 50
+
+# Magnitude range [min, max] for injected objects (Generative mode)
+mag_range = [19.0, 26.0]
+
+# Path to a parquet file mapping IC filepaths to pre-computed catalog filepaths (Pre-Computed mode)
+# If specified and a matching catalog is found, generation is bypassed.
+# The parquet should have columns: "ic_filepath" and "catalog_filepath"
+# catalog_mapping_path = "/path/to/catalog_mapping.parquet"
+
 
 [apps.reproject_wu]
 # Number of processors to use for parallelizing the reprojection

--- a/src/kbmod_wf/resource_configs/usdf_configuration.py
+++ b/src/kbmod_wf/resource_configs/usdf_configuration.py
@@ -20,7 +20,13 @@ import logging  # COC
 import numpy as np
 import platform
 
-nodename_map = {"sdfada": "ada", "sdfampere": "ampere", "sdfroma": "roma", "sdfmilano": "milano"}
+nodename_map = {
+    "sdfada": "ada",
+    "sdfampere": "ampere",
+    "sdfroma": "roma",
+    "sdfmilano": "milano",
+    "sdftorino": "torino",
+}
 
 slurm_cmd_timeout = 60  # default is 10 and that is timing out for sacct -X 5/1/2025 COC
 
@@ -29,6 +35,7 @@ max_ram_dict = {
     "ampere": 952,  # 896 per each of the two nodes we can access, each with 4 GPUs
     "roma": 140,  # 240 to 140
     "milano": 140,  # 240 to 140
+    "torino": 700,  # 2/3/2026 COC/WSB
 }
 max_block_dict = {"ada": 1, "ampere": 2}
 gpus_per_node_dict = {"ada": 5, "ampere": 4}
@@ -46,6 +53,12 @@ cpu_partition = cpus_for_gpus_dict[gpu_partition]
 if "GPUNODE" in os.environ:
     gpu_partition = os.environ["GPUNODE"].lower()
     print(f"Set gpu_partition to {gpu_partition} via environment variable GPUNODE.")
+
+
+# 2/3/2026 COC
+if "CPUNODE" in os.environ:
+    cpu_partition = os.environ["CPUNODE"].lower()
+    print(f"Set cpu_partition to {cpu_partition} via environment variable CPUNODE.")
 
 
 walltimes = {
@@ -93,8 +106,8 @@ def usdf_resource_config():
                 provider=SlurmProvider(
                     partition=gpu_partition,  # or ada
                     account=account_name,
-                    min_blocks=max_nodes_dict[gpu_partition],  # was 0
-                    init_blocks=max_nodes_dict[gpu_partition],  # added 4/29/2025 COC
+                    min_blocks=0,  # was 0
+                    init_blocks=0,  # added 4/29/2025 COC
                     max_blocks=max_block_dict[
                         gpu_partition
                     ],  # 8 to 24 4/16/2025 COC to 12 4/20/2025 COC to 8 4/22/2025 COC

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -86,10 +86,10 @@ class ICtoWUConverter:
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to inject objects into ImageCollection.")
 
-        # Save injected catalog
+        # Save injected catalog as parquet alongside the input ImageCollection
         last_time = time.time()
-        injected_cat_filepath = self.ic_filepath.replace(".collection", "_injected_catalog.ecsv")
-        injected_cats.write(injected_cat_filepath, overwrite=True)
+        injected_cat_filepath = self.ic_filepath + ".injection_cat.parquet"
+        injected_cats.to_pandas().to_parquet(injected_cat_filepath)
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to save injected catalog to: {injected_cat_filepath}")
 
@@ -138,204 +138,19 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, n_objs_
     tuple
         A tuple containing the injected ImageCollection, the injected catalogs, and the global WCS.
     """
-    ## Load required configs and resources
+    from kbmod.configuration import SearchConfiguration
+
     search_config = SearchConfiguration.from_file(
         runtime_config["apps"]["reproject_wu"]["search_config_filepath"]
     )
 
-    # sort this here so we can rely on ordering later
-    ic.data.sort("mjd_mid")
-
-    # Procedure:
-    # - get WCS
-    # - get an TrajectoryGenerator
-    # - extract N random vx, vy of trajectories from an trajectory sample
-    #       This ensures that all our trajectories are always sampled from within the search limits
-    # - use those to generate (x, y, obstime) coordinates
-    # - convert those to (ra, dec, obstime) coordinates catalog
-    #       This is done by using the WCS of a single image
-    #       Let's say the first one.
-    #       As long as a straight line in the image is approximately a straight line in the sky,
-    #       i.e. as long as the image is not such a wide-field that TAN approximation does not follow great circles on the sky,
-    #       the trail should be a straight line in (ra, dec)
-    # - Invert correct for a parallax at a distance
-    # - Go through the references in the ImageCollection and run VisitInjectTask on each
-    # - store the resulting injected catalog, exposure with injected objects and mask in a list
-    # - run through every standardizer and overwrite the std.exp and std.ref attributes with the new ones
-    # - vstack all the individual returned injected catalogs into a big one for the WorkUnit and write it to disk
-    # - create a new ImageCollection.fromStandardizers
-
-    # Catalog generation:
-    # - get wcs
-    global_wcs = WCS(ic.data["global_wcs"][0])
-    global_wcs.pixel_shape = (
-        ic.data["global_wcs_pixel_shape_0"][0],
-        ic.data["global_wcs_pixel_shape_1"][0],
+    catalog = ic.generate_injection_catalog(
+        search_config=search_config,
+        global_wcs=ic.get_global_wcs(auto_fit=False),
+        n_objs_per_ic=n_objs_per_ic,
+        guess_distance=heliocentric_distance,
     )
 
-    # - get a sample of trajectories from TgajectoryGenerator
-    eclip_angle = kbmod.wcs_utils.calc_ecliptic_angle(global_wcs)
-    trjgen = kbmod.trajectory_generator.create_trajectory_generator(
-        search_config["generator_config"], given_ecliptic=eclip_angle
-    )
-    candidates = [trj for trj in trjgen]
-    trjs = np.random.choice(candidates, N_OBJS_PER_IC)
+    injected_ic, injected_cats = ic.inject_sources(catalog=catalog, butler=butler)
 
-    # - generate a random sample of starting points within image bounds
-    # - grab the vx, vy from the sampled trajectories
-    # - figure out the pixel limits within which we're generating our starting pixels.
-    #       We have 2 options here, we can get the imdiffs before-hand and query them:
-    # ```maxy, maxx = imdiff.getBBox().getWidth(), imdiff.getBBox().getHeight() ```
-    #       or we can use the global WCS to get the bounding box:
-    pixel_boundaries = global_wcs.world_to_pixel(
-        SkyCoord(global_wcs.calc_footprint()[:, 0], global_wcs.calc_footprint()[:, 1], unit="degree")
-    )
-    maxx = max(pixel_boundaries[0])
-    maxy = max(pixel_boundaries[1])
-    xs = np.random.randint(
-        0, maxx, N_OBJS_PER_IC
-    )  # seems ys and xs are flipped because iamge origin is in different place
-    ys = np.random.randint(0, maxy, N_OBJS_PER_IC)
-    vxs = np.array([t.vx for t in trjs])
-    vys = np.array([t.vy for t in trjs])
-
-    # - generate all positions of an object in the image_collection using the timestamps
-    #       The np.diff gives back len()-1 array because it skips the first position.
-    #       We set that diff to 0, to effectively copy the randomly sampled initial positions into
-    #       the injection catalog, and that makes the N obstimes copacetic with the N dt's.
-    #       A quirk of this approach is that first position is always nicely rounded pixel coordinate.
-    obstimes = ic["mjd_mid"]
-    obstimes.sort()
-    dts = np.zeros(len(obstimes))
-    dts[1:] = np.diff(obstimes)
-    xs = xs[:, None] + dts * vxs[:, None]
-    ys = ys[:, None] + dts * vys[:, None]
-    sky_coords = global_wcs.pixel_to_world(xs, ys)
-
-    # - invert-correct for a heliocentric distance
-    sky_coords_with_distance = SkyCoord(
-        sky_coords.ra, sky_coords.dec, distance=heliocentric_distance * u.au, frame="icrs"
-    )
-    loc = EarthLocation.of_site("Rubin")
-    invert_corrected_skycoords = kbmod.reprojection_utils.invert_correct_parallax_vectorized(
-        sky_coords_with_distance, obstimes, loc
-    )
-    invert_corrected_skycoords = sky_coords
-
-    # Now collate a catalog for injection
-    _xs, _ys, exp_id, mags, obj_ids, ts = [], [], [], [], [], []
-    for (
-        i,
-        x,
-    ) in enumerate(xs):
-        # _xs.extend(x)
-        obj_ids.extend(
-            [
-                i,
-            ]
-            * len(x)
-        )
-        mag = np.random.uniform(19, 26)
-        mags.extend(
-            [
-                mag,
-            ]
-            * len(x)
-        )
-        ts.extend(obstimes)
-
-    catalog = Table(
-        {
-            "injection_id": np.arange(0, len(obj_ids), 1),
-            "ra": invert_corrected_skycoords.ra.deg.ravel(),
-            "dec": invert_corrected_skycoords.dec.deg.ravel(),
-            "mag": mags,
-            "distance": [
-                heliocentric_distance,
-            ]
-            * len(obj_ids),
-            "source_type": [
-                "Star",
-            ]
-            * len(obj_ids),
-            "obj_ids": obj_ids,
-            "obstime": ts,
-            "x": xs.ravel(),
-            "y": ys.ravel(),
-        }
-    )
-
-    catalog = catalog.group_by("obstime")
-    if len(catalog.groups) != len(ic):
-        # is this really unexpected?
-        raise RuntimeError("Generated catalog is missing entries for some images in collection.")
-
-    # Injection stage
-    # - set up the injection task
-    # - set up references, exposures and injected_catalogs lists
-    # - inject
-    inject_config = VisitInjectConfig()
-    inject_task = VisitInjectTask(config=inject_config)
-
-    ## Load images to inject into
-    references, exposures, injected_cats = [], [], []
-    for idd, srccat in zip(ic["dataId"], catalog.groups):
-        did = dafButler.DatasetId(idd)
-        ref = butler.get_dataset(did, dimension_records=True)
-        imdiff = butler.get(ref)
-        # !!! TESTING !!!
-        # imdiff.image.array = np.zeros(imdiff.image.array.shape)
-        # imdiff.image.getArray()[:] = np.zeros(imdiff.image.array.shape, dtype=float)
-        try:
-            injected_output = inject_task.run(
-                injection_catalogs=srccat,
-                input_exposure=imdiff,  # .clone(), # !!! we might probably be fine not cloning this image here
-                psf=imdiff.psf,
-                photo_calib=imdiff.photoCalib,
-                wcs=imdiff.wcs,
-            )
-        except RuntimeError:  # no sources were injected
-            print(f"{idd} has no injected objects!")
-            injected_exposure = imdiff
-            injected_catalog = Table(
-                {
-                    "injection_id": [],
-                    "ra": [],
-                    "dec": [],
-                    "mag": [],
-                    "distance": [],
-                    "source_type": [],
-                    "obj_ids": [],
-                    "obstime": [],
-                    "x": [],
-                    "y": [],
-                }
-            )
-        else:
-            injected_exposure = injected_output.output_exposure
-            injected_catalog = injected_output.output_catalog
-            print(f"Injected {len(injected_catalog)} objects into {idd}.")
-        references.append(ref)
-        exposures.append(injected_exposure)
-        injected_cats.append(injected_catalog)
-
-    # Injection post-processing stage
-    # - stack the injected catalogs and write the to the correct place
-    # - get standardizers and overwrite their exposures and references
-    injected_cats = vstack(injected_cats)
-    injected_cats.write("results_place_injected_src.cat", format="ascii.ecsv", overwrite=True)
-    standardizers = ic.get_standardizers(butler=butler)
-    if len(catalog.groups) != len(ic):
-        raise RuntimeError(
-            "Number of created standardizers does not match the number of exposures recovered after injection."
-        )
-
-    # now just overwrite the actual image arrays within each standardizer and
-    # return that collection
-    for std, ref, exp in zip(standardizers, references, exposures):
-        std["std"].exp = exp
-        std["std"].ref = ref
-
-    # Finally make a new image collection out of these standardizers
-    ic = ImageCollection.fromStandardizers([std["std"] for std in standardizers])
-    return ic, injected_cats, global_wcs
+    return injected_ic, injected_cats, None

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -1,11 +1,13 @@
+import os
+import time
+from logging import Logger
+
+import pandas as pd
+from astropy.table import Table
+
 from kbmod import ImageCollection
 from kbmod.configuration import SearchConfiguration
 from lsst.daf.butler import Butler
-
-import os
-import glob
-import time
-from logging import Logger
 
 
 def ic_to_wu(
@@ -81,7 +83,12 @@ class ICtoWUConverter:
 
         last_time = time.time()
         ic, injected_cats, global_wcs = ic_to_injected_ic(
-            ic, this_butler, self.runtime_config, self.guess_dist
+            ic,
+            this_butler,
+            self.runtime_config,
+            self.guess_dist,
+            ic_filepath=self.ic_filepath,
+            logger=self.logger,
         )
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to inject objects into ImageCollection.")
@@ -114,11 +121,13 @@ class ICtoWUConverter:
         return self.wu_filepath
 
 
-def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, n_objs_per_ic=50):
+def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_filepath=None, logger=None):
     """
-    This function will take an ImageCollection and inject synthetic solar system objects into it.
+    Inject synthetic solar system objects into an ImageCollection.
 
-    TODO update n_objs_per_ic to be a parameter in the config file
+    Supports two modes:
+    1. **Generative**: Randomly generate an injection catalog using `ic.generate_injection_catalog()`
+    2. **Pre-Computed**: Load a pre-existing catalog from a mapping file
 
     Parameters
     ----------
@@ -127,28 +136,200 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, n_objs_
     butler : Butler
         The butler instance to use for the workflow.
     runtime_config : dict
-        The runtime configuration for the workflow.
+        The runtime configuration for the workflow. May contain an "injection" subsection with:
+        - n_objs_per_ic : int - Number of objects to inject (default: 50)
+        - mag_range : list - [min, max] magnitude range (default: [19.0, 26.0])
+        - catalog_mapping_path : str - Path to parquet file mapping IC paths to catalog paths
     heliocentric_distance : float
-        The heliocentric distance of the objects to inject.
-    n_objs_per_ic : int, optional
-        The number of objects to inject per ImageCollection, by default 50.
+        The heliocentric distance (AU) of the objects to inject.
+    ic_filepath : str, optional
+        The filepath of the input ImageCollection, used for catalog mapping lookup.
+    logger : Logger, optional
+        Logger for debug output.
 
     Returns
     -------
     tuple
-        A tuple containing the injected ImageCollection, the injected catalogs, and the global WCS.
+        A tuple containing (injected_ic, injected_cats, global_wcs).
+
+    Raises
+    ------
+    RuntimeError
+        If the standardizer does not support the "INJECTED" mask plane.
+    ValueError
+        If catalog_mapping_path is specified but no matching catalog is found.
     """
-    from kbmod.configuration import SearchConfiguration
+    # Get injection-specific config (may be nested under "injection" key)
+    injection_config = runtime_config.get("injection", {})
 
-    search_config = SearchConfiguration.from_file(runtime_config.get("search_config_filepath", None))
+    # Extract config parameters with defaults
+    n_objs_per_ic = injection_config.get("n_objs_per_ic", 50)
+    mag_range = injection_config.get("mag_range", [19.0, 26.0])
+    catalog_mapping_path = injection_config.get("catalog_mapping_path", None)
 
-    catalog = ic.generate_injection_catalog(
-        search_config=search_config,
-        global_wcs=ic.get_global_wcs(auto_fit=False),
-        n_objs_per_ic=n_objs_per_ic,
-        guess_distance=heliocentric_distance,
-    )
+    if logger:
+        logger.debug(f"Injection config: n_objs={n_objs_per_ic}, mag_range={mag_range}")
 
+    # Safety validation: Check for INJECTED bit flag support
+    _validate_injected_mask_support(ic, butler, logger)
+
+    # Determine catalog source: pre-computed or generative
+    catalog = None
+
+    if catalog_mapping_path is not None:
+        # Pre-computed catalog mode: look up catalog path from mapping file
+        catalog = _load_catalog_from_mapping(catalog_mapping_path, ic_filepath, logger)
+
+    if catalog is None:
+        # Generative mode: create catalog using kbmod's injection module
+        if logger:
+            logger.info(f"Generating injection catalog with {n_objs_per_ic} objects")
+
+        search_config = SearchConfiguration.from_file(runtime_config.get("search_config_filepath", None))
+
+        catalog = ic.generate_injection_catalog(
+            search_config=search_config,
+            global_wcs=ic.get_global_wcs(auto_fit=False),
+            n_objs_per_ic=n_objs_per_ic,
+            guess_distance=heliocentric_distance,
+            mag_range=tuple(mag_range),
+        )
+
+    # Perform the injection
     injected_ic, injected_cats = ic.inject_sources(catalog=catalog, butler=butler)
 
     return injected_ic, injected_cats, None
+
+
+def _validate_injected_mask_support(ic, butler, logger=None):
+    """
+    Validate that the standardizer supports the "INJECTED" mask plane.
+
+    This checks that the underlying exposure's mask plane dictionary contains
+    the "INJECTED" bit flag, which is required for proper source injection tracking.
+
+    Parameters
+    ----------
+    ic : ImageCollection
+        The ImageCollection to validate.
+    butler : Butler
+        The butler instance to retrieve exposures.
+    logger : Logger, optional
+        Logger for debug output.
+
+    Raises
+    ------
+    RuntimeError
+        If the "INJECTED" mask plane is not supported.
+    """
+    try:
+        standardizers = ic.get_standardizers(butler=butler)
+        if not standardizers:
+            if logger:
+                logger.warning("No standardizers found, skipping INJECTED mask validation")
+            return
+
+        # Check the first standardizer's mask plane dict
+        std = standardizers[0]["std"]
+
+        # The standardizer should have an exposure with a mask
+        if hasattr(std, "exp") and std.exp is not None:
+            mask_plane_dict = std.exp.mask.getMaskPlaneDict()
+            if "INJECTED" not in mask_plane_dict:
+                raise RuntimeError(
+                    "The standardizer's exposure does not support the 'INJECTED' mask plane. "
+                    "Source injection tracking requires this mask plane to be defined. "
+                    f"Available mask planes: {list(mask_plane_dict.keys())}"
+                )
+            if logger:
+                logger.debug("INJECTED mask plane validation passed")
+        else:
+            if logger:
+                logger.warning("Standardizer has no exposure loaded, skipping INJECTED mask validation")
+
+    except Exception as e:
+        if "INJECTED" in str(e):
+            raise
+        if logger:
+            logger.warning(f"Could not validate INJECTED mask support: {e}")
+
+
+def _load_catalog_from_mapping(mapping_path, ic_filepath, logger=None):
+    """
+    Load a pre-computed injection catalog from a mapping file.
+
+    The mapping file is a parquet table with columns:
+    - ic_filepath: The path to the ImageCollection file
+    - catalog_filepath: The path to the corresponding injection catalog
+
+    Parameters
+    ----------
+    mapping_path : str
+        Path to the parquet mapping file.
+    ic_filepath : str
+        The filepath of the current ImageCollection to look up.
+    logger : Logger, optional
+        Logger for debug output.
+
+    Returns
+    -------
+    astropy.table.Table or None
+        The loaded catalog, or None if no mapping was found.
+    """
+    if not os.path.exists(mapping_path):
+        if logger:
+            logger.warning(f"Catalog mapping file not found: {mapping_path}")
+        return None
+
+    if logger:
+        logger.info(f"Loading catalog mapping from: {mapping_path}")
+
+    mapping_df = pd.read_parquet(mapping_path)
+
+    # Normalize the IC filepath for comparison
+    ic_filepath_normalized = os.path.abspath(ic_filepath) if ic_filepath else None
+
+    # Look up the catalog path
+    if "ic_filepath" not in mapping_df.columns or "catalog_filepath" not in mapping_df.columns:
+        if logger:
+            logger.warning(
+                f"Mapping file missing required columns. Expected 'ic_filepath' and 'catalog_filepath', "
+                f"got: {list(mapping_df.columns)}"
+            )
+        return None
+
+    # Try exact match first, then normalized paths
+    match = mapping_df[mapping_df["ic_filepath"] == ic_filepath]
+    if len(match) == 0 and ic_filepath_normalized:
+        # Try with normalized paths
+        mapping_df["ic_filepath_norm"] = mapping_df["ic_filepath"].apply(
+            lambda x: os.path.abspath(x) if x else None
+        )
+        match = mapping_df[mapping_df["ic_filepath_norm"] == ic_filepath_normalized]
+
+    if len(match) == 0:
+        if logger:
+            logger.info(f"No pre-computed catalog found for IC: {ic_filepath}")
+        return None
+
+    catalog_path = match.iloc[0]["catalog_filepath"]
+    if logger:
+        logger.info(f"Found pre-computed catalog: {catalog_path}")
+
+    # Load the catalog
+    if not os.path.exists(catalog_path):
+        if logger:
+            logger.warning(f"Mapped catalog file not found: {catalog_path}")
+        return None
+
+    if catalog_path.endswith(".parquet"):
+        catalog = Table.from_pandas(pd.read_parquet(catalog_path))
+    elif catalog_path.endswith(".ecsv"):
+        catalog = Table.read(catalog_path, format="ascii.ecsv")
+    else:
+        catalog = Table.read(catalog_path)
+
+    if logger:
+        logger.info(f"Loaded pre-computed catalog with {len(catalog)} rows")
+
+    return catalog

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -81,24 +81,29 @@ class ICtoWUConverter:
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to instantiate butler.")
 
-        last_time = time.time()
-        ic, injected_cats, global_wcs = ic_to_injected_ic(
-            ic,
-            this_butler,
-            self.runtime_config,
-            self.guess_dist,
-            ic_filepath=self.ic_filepath,
-            logger=self.logger,
-        )
-        elapsed = round(time.time() - last_time, 1)
-        self.logger.debug(f"Required {elapsed}[s] to inject objects into ImageCollection.")
+        # Check if injection is configured - skip entirely if not
+        injection_config = self.runtime_config.get("injection", None)
+        if injection_config is None:
+            self.logger.info("No injection config provided, skipping injection step.")
+        else:
+            last_time = time.time()
+            ic, injected_cats = ic_to_injected_ic(
+                ic,
+                this_butler,
+                self.runtime_config,
+                self.guess_dist,
+                ic_filepath=self.ic_filepath,
+                logger=self.logger,
+            )
+            elapsed = round(time.time() - last_time, 1)
+            self.logger.debug(f"Required {elapsed}[s] to inject objects into ImageCollection.")
 
-        # Save injected catalog as parquet alongside the input ImageCollection
-        last_time = time.time()
-        injected_cat_filepath = str(self.ic_filepath) + ".injection_cat.parquet"
-        injected_cats.to_pandas().to_parquet(injected_cat_filepath)
-        elapsed = round(time.time() - last_time, 1)
-        self.logger.debug(f"Required {elapsed}[s] to save injected catalog to: {injected_cat_filepath}")
+            # Save injected catalog as parquet alongside the input ImageCollection
+            last_time = time.time()
+            injected_cat_filepath = str(self.ic_filepath) + ".injection_cat.parquet"
+            injected_cats.to_pandas().to_parquet(injected_cat_filepath)
+            elapsed = round(time.time() - last_time, 1)
+            self.logger.debug(f"Required {elapsed}[s] to save injected catalog to: {injected_cat_filepath}")
 
         last_time = time.time()
         orig_wu = ic.toWorkUnit(
@@ -121,7 +126,7 @@ class ICtoWUConverter:
         return self.wu_filepath
 
 
-def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_filepath=None, logger=None):
+def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_filepath, logger=None):
     """
     Inject synthetic solar system objects into an ImageCollection.
 
@@ -142,15 +147,16 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_file
         - catalog_mapping_path : str - Path to parquet file mapping IC paths to catalog paths
     heliocentric_distance : float
         The heliocentric distance (AU) of the objects to inject.
-    ic_filepath : str, optional
-        The filepath of the input ImageCollection, used for catalog mapping lookup.
+    ic_filepath : str
+        The filepath of the input ImageCollection, used for catalog mapping lookup
+        and for saving provenance catalogs.
     logger : Logger, optional
         Logger for debug output.
 
     Returns
     -------
     tuple
-        A tuple containing (injected_ic, injected_cats, global_wcs).
+        A tuple containing (injected_ic, injected_cats).
 
     Raises
     ------
@@ -195,10 +201,16 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_file
             mag_range=tuple(mag_range),
         )
 
+    # Save input catalog for provenance (before injection may filter some sources)
+    input_cat_filepath = str(ic_filepath) + ".injection_input_cat.parquet"
+    catalog.to_pandas().to_parquet(input_cat_filepath)
+    if logger:
+        logger.debug(f"Saved input catalog for provenance: {input_cat_filepath}")
+
     # Perform the injection
     injected_ic, injected_cats = ic.inject_sources(catalog=catalog, butler=butler)
 
-    return injected_ic, injected_cats, None
+    return injected_ic, injected_cats
 
 
 def _validate_injected_mask_support(ic, butler, logger=None):

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -88,7 +88,7 @@ class ICtoWUConverter:
 
         # Save injected catalog as parquet alongside the input ImageCollection
         last_time = time.time()
-        injected_cat_filepath = self.ic_filepath + ".injection_cat.parquet"
+        injected_cat_filepath = str(self.ic_filepath) + ".injection_cat.parquet"
         injected_cats.to_pandas().to_parquet(injected_cat_filepath)
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to save injected catalog to: {injected_cat_filepath}")
@@ -140,9 +140,7 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, n_objs_
     """
     from kbmod.configuration import SearchConfiguration
 
-    search_config = SearchConfiguration.from_file(
-        runtime_config["apps"]["reproject_wu"]["search_config_filepath"]
-    )
+    search_config = SearchConfiguration.from_file(runtime_config.get("search_config_filepath", None))
 
     catalog = ic.generate_injection_catalog(
         search_config=search_config,

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -7,6 +7,7 @@ from astropy.table import Table
 
 from kbmod import ImageCollection
 from kbmod.configuration import SearchConfiguration
+from kbmod.injection import generate_injection_catalog, inject_sources_into_ic
 from lsst.daf.butler import Butler
 
 
@@ -131,7 +132,7 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_file
     Inject synthetic solar system objects into an ImageCollection.
 
     Supports two modes:
-    1. **Generative**: Randomly generate an injection catalog using `ic.generate_injection_catalog()`
+    1. **Generative**: Randomly generate an injection catalog using `generate_injection_catalog()`
     2. **Pre-Computed**: Load a pre-existing catalog from a mapping file
 
     Parameters
@@ -193,7 +194,8 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_file
 
         search_config = SearchConfiguration.from_file(runtime_config.get("search_config_filepath", None))
 
-        catalog = ic.generate_injection_catalog(
+        catalog = generate_injection_catalog(
+            ic=ic,
             search_config=search_config,
             global_wcs=ic.get_global_wcs(auto_fit=False),
             n_objs_per_ic=n_objs_per_ic,
@@ -208,7 +210,7 @@ def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, ic_file
         logger.debug(f"Saved input catalog for provenance: {input_cat_filepath}")
 
     # Perform the injection
-    injected_ic, injected_cats = ic.inject_sources(catalog=catalog, butler=butler)
+    injected_ic, injected_cats = inject_sources_into_ic(ic, catalog=catalog, butler=butler)
 
     return injected_ic, injected_cats
 

--- a/src/kbmod_wf/task_impls/ic_to_wu.py
+++ b/src/kbmod_wf/task_impls/ic_to_wu.py
@@ -14,6 +14,7 @@ def ic_to_wu(
     save: bool = True,
     runtime_config: dict = {},
     logger: Logger = None,
+    guess_dist: float = None,
 ):
     """This task will convert an ImageCollection to a WorkUnit.
 
@@ -29,6 +30,8 @@ def ic_to_wu(
         Additional configuration parameters to be used at runtime, by default {}
     logger : Logger, optional
         Primary logger for the workflow, by default None
+    guess_dist : float, optional
+        The guess distance for the WorkUnit, by default None
 
     Returns
     -------
@@ -41,6 +44,7 @@ def ic_to_wu(
         save=save,
         runtime_config=runtime_config,
         logger=logger,
+        guess_dist=guess_dist,
     )
 
     return ic_to_wu_converter.create_work_unit()
@@ -54,12 +58,14 @@ class ICtoWUConverter:
         save: bool = True,
         runtime_config: dict = {},
         logger: Logger = None,
+        guess_dist: float = None,
     ):
         self.ic_filepath = ic_filepath
         self.wu_filepath = wu_filepath
         self.save = save
         self.runtime_config = runtime_config
         self.logger = logger
+        self.guess_dist = guess_dist
 
         self.search_config_filepath = self.runtime_config.get("search_config_filepath", None)
 
@@ -72,6 +78,20 @@ class ICtoWUConverter:
         this_butler = Butler(self.runtime_config.get("butler_config_filepath", None))
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(f"Required {elapsed}[s] to instantiate butler.")
+
+        last_time = time.time()
+        ic, injected_cats, global_wcs = ic_to_injected_ic(
+            ic, this_butler, self.runtime_config, self.guess_dist
+        )
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"Required {elapsed}[s] to inject objects into ImageCollection.")
+
+        # Save injected catalog
+        last_time = time.time()
+        injected_cat_filepath = self.ic_filepath.replace(".collection", "_injected_catalog.ecsv")
+        injected_cats.write(injected_cat_filepath, overwrite=True)
+        elapsed = round(time.time() - last_time, 1)
+        self.logger.debug(f"Required {elapsed}[s] to save injected catalog to: {injected_cat_filepath}")
 
         last_time = time.time()
         orig_wu = ic.toWorkUnit(
@@ -92,3 +112,230 @@ class ICtoWUConverter:
         self.logger.debug(f"Required {elapsed}[s] to write WorkUnit to disk: {self.wu_filepath}")
 
         return self.wu_filepath
+
+
+def ic_to_injected_ic(ic, butler, runtime_config, heliocentric_distance, n_objs_per_ic=50):
+    """
+    This function will take an ImageCollection and inject synthetic solar system objects into it.
+
+    TODO update n_objs_per_ic to be a parameter in the config file
+
+    Parameters
+    ----------
+    ic : ImageCollection
+        The ImageCollection to inject objects into.
+    butler : Butler
+        The butler instance to use for the workflow.
+    runtime_config : dict
+        The runtime configuration for the workflow.
+    heliocentric_distance : float
+        The heliocentric distance of the objects to inject.
+    n_objs_per_ic : int, optional
+        The number of objects to inject per ImageCollection, by default 50.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the injected ImageCollection, the injected catalogs, and the global WCS.
+    """
+    ## Load required configs and resources
+    search_config = SearchConfiguration.from_file(
+        runtime_config["apps"]["reproject_wu"]["search_config_filepath"]
+    )
+
+    # sort this here so we can rely on ordering later
+    ic.data.sort("mjd_mid")
+
+    # Procedure:
+    # - get WCS
+    # - get an TrajectoryGenerator
+    # - extract N random vx, vy of trajectories from an trajectory sample
+    #       This ensures that all our trajectories are always sampled from within the search limits
+    # - use those to generate (x, y, obstime) coordinates
+    # - convert those to (ra, dec, obstime) coordinates catalog
+    #       This is done by using the WCS of a single image
+    #       Let's say the first one.
+    #       As long as a straight line in the image is approximately a straight line in the sky,
+    #       i.e. as long as the image is not such a wide-field that TAN approximation does not follow great circles on the sky,
+    #       the trail should be a straight line in (ra, dec)
+    # - Invert correct for a parallax at a distance
+    # - Go through the references in the ImageCollection and run VisitInjectTask on each
+    # - store the resulting injected catalog, exposure with injected objects and mask in a list
+    # - run through every standardizer and overwrite the std.exp and std.ref attributes with the new ones
+    # - vstack all the individual returned injected catalogs into a big one for the WorkUnit and write it to disk
+    # - create a new ImageCollection.fromStandardizers
+
+    # Catalog generation:
+    # - get wcs
+    global_wcs = WCS(ic.data["global_wcs"][0])
+    global_wcs.pixel_shape = (
+        ic.data["global_wcs_pixel_shape_0"][0],
+        ic.data["global_wcs_pixel_shape_1"][0],
+    )
+
+    # - get a sample of trajectories from TgajectoryGenerator
+    eclip_angle = kbmod.wcs_utils.calc_ecliptic_angle(global_wcs)
+    trjgen = kbmod.trajectory_generator.create_trajectory_generator(
+        search_config["generator_config"], given_ecliptic=eclip_angle
+    )
+    candidates = [trj for trj in trjgen]
+    trjs = np.random.choice(candidates, N_OBJS_PER_IC)
+
+    # - generate a random sample of starting points within image bounds
+    # - grab the vx, vy from the sampled trajectories
+    # - figure out the pixel limits within which we're generating our starting pixels.
+    #       We have 2 options here, we can get the imdiffs before-hand and query them:
+    # ```maxy, maxx = imdiff.getBBox().getWidth(), imdiff.getBBox().getHeight() ```
+    #       or we can use the global WCS to get the bounding box:
+    pixel_boundaries = global_wcs.world_to_pixel(
+        SkyCoord(global_wcs.calc_footprint()[:, 0], global_wcs.calc_footprint()[:, 1], unit="degree")
+    )
+    maxx = max(pixel_boundaries[0])
+    maxy = max(pixel_boundaries[1])
+    xs = np.random.randint(
+        0, maxx, N_OBJS_PER_IC
+    )  # seems ys and xs are flipped because iamge origin is in different place
+    ys = np.random.randint(0, maxy, N_OBJS_PER_IC)
+    vxs = np.array([t.vx for t in trjs])
+    vys = np.array([t.vy for t in trjs])
+
+    # - generate all positions of an object in the image_collection using the timestamps
+    #       The np.diff gives back len()-1 array because it skips the first position.
+    #       We set that diff to 0, to effectively copy the randomly sampled initial positions into
+    #       the injection catalog, and that makes the N obstimes copacetic with the N dt's.
+    #       A quirk of this approach is that first position is always nicely rounded pixel coordinate.
+    obstimes = ic["mjd_mid"]
+    obstimes.sort()
+    dts = np.zeros(len(obstimes))
+    dts[1:] = np.diff(obstimes)
+    xs = xs[:, None] + dts * vxs[:, None]
+    ys = ys[:, None] + dts * vys[:, None]
+    sky_coords = global_wcs.pixel_to_world(xs, ys)
+
+    # - invert-correct for a heliocentric distance
+    sky_coords_with_distance = SkyCoord(
+        sky_coords.ra, sky_coords.dec, distance=heliocentric_distance * u.au, frame="icrs"
+    )
+    loc = EarthLocation.of_site("Rubin")
+    invert_corrected_skycoords = kbmod.reprojection_utils.invert_correct_parallax_vectorized(
+        sky_coords_with_distance, obstimes, loc
+    )
+    invert_corrected_skycoords = sky_coords
+
+    # Now collate a catalog for injection
+    _xs, _ys, exp_id, mags, obj_ids, ts = [], [], [], [], [], []
+    for (
+        i,
+        x,
+    ) in enumerate(xs):
+        # _xs.extend(x)
+        obj_ids.extend(
+            [
+                i,
+            ]
+            * len(x)
+        )
+        mag = np.random.uniform(19, 26)
+        mags.extend(
+            [
+                mag,
+            ]
+            * len(x)
+        )
+        ts.extend(obstimes)
+
+    catalog = Table(
+        {
+            "injection_id": np.arange(0, len(obj_ids), 1),
+            "ra": invert_corrected_skycoords.ra.deg.ravel(),
+            "dec": invert_corrected_skycoords.dec.deg.ravel(),
+            "mag": mags,
+            "distance": [
+                heliocentric_distance,
+            ]
+            * len(obj_ids),
+            "source_type": [
+                "Star",
+            ]
+            * len(obj_ids),
+            "obj_ids": obj_ids,
+            "obstime": ts,
+            "x": xs.ravel(),
+            "y": ys.ravel(),
+        }
+    )
+
+    catalog = catalog.group_by("obstime")
+    if len(catalog.groups) != len(ic):
+        # is this really unexpected?
+        raise RuntimeError("Generated catalog is missing entries for some images in collection.")
+
+    # Injection stage
+    # - set up the injection task
+    # - set up references, exposures and injected_catalogs lists
+    # - inject
+    inject_config = VisitInjectConfig()
+    inject_task = VisitInjectTask(config=inject_config)
+
+    ## Load images to inject into
+    references, exposures, injected_cats = [], [], []
+    for idd, srccat in zip(ic["dataId"], catalog.groups):
+        did = dafButler.DatasetId(idd)
+        ref = butler.get_dataset(did, dimension_records=True)
+        imdiff = butler.get(ref)
+        # !!! TESTING !!!
+        # imdiff.image.array = np.zeros(imdiff.image.array.shape)
+        # imdiff.image.getArray()[:] = np.zeros(imdiff.image.array.shape, dtype=float)
+        try:
+            injected_output = inject_task.run(
+                injection_catalogs=srccat,
+                input_exposure=imdiff,  # .clone(), # !!! we might probably be fine not cloning this image here
+                psf=imdiff.psf,
+                photo_calib=imdiff.photoCalib,
+                wcs=imdiff.wcs,
+            )
+        except RuntimeError:  # no sources were injected
+            print(f"{idd} has no injected objects!")
+            injected_exposure = imdiff
+            injected_catalog = Table(
+                {
+                    "injection_id": [],
+                    "ra": [],
+                    "dec": [],
+                    "mag": [],
+                    "distance": [],
+                    "source_type": [],
+                    "obj_ids": [],
+                    "obstime": [],
+                    "x": [],
+                    "y": [],
+                }
+            )
+        else:
+            injected_exposure = injected_output.output_exposure
+            injected_catalog = injected_output.output_catalog
+            print(f"Injected {len(injected_catalog)} objects into {idd}.")
+        references.append(ref)
+        exposures.append(injected_exposure)
+        injected_cats.append(injected_catalog)
+
+    # Injection post-processing stage
+    # - stack the injected catalogs and write the to the correct place
+    # - get standardizers and overwrite their exposures and references
+    injected_cats = vstack(injected_cats)
+    injected_cats.write("results_place_injected_src.cat", format="ascii.ecsv", overwrite=True)
+    standardizers = ic.get_standardizers(butler=butler)
+    if len(catalog.groups) != len(ic):
+        raise RuntimeError(
+            "Number of created standardizers does not match the number of exposures recovered after injection."
+        )
+
+    # now just overwrite the actual image arrays within each standardizer and
+    # return that collection
+    for std, ref, exp in zip(standardizers, references, exposures):
+        std["std"].exp = exp
+        std["std"].ref = ref
+
+    # Finally make a new image collection out of these standardizers
+    ic = ImageCollection.fromStandardizers([std["std"] for std in standardizers])
+    return ic, injected_cats, global_wcs

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -134,7 +134,7 @@ class KBMODSearcher:
 
         if self.cleanup_wu:
             self.logger.info(f"Cleaning up sharded WorkUnit {self.input_wu_filepath} with {len(wu)}")
-            # Delete the head filefor the WorkUnit
+            # Delete the head file for the WorkUnit
             try:
                 os.remove(self.input_wu_filepath)
             except Exception as e:

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -1,4 +1,5 @@
 import kbmod
+from kbmod.injection import match_injection_results
 from kbmod.search import kb_has_gpu
 from kbmod.work_unit import WorkUnit
 
@@ -105,6 +106,27 @@ class KBMODSearcher:
         res = kbmod.run_search.SearchRunner().run_search_from_work_unit(wu)
         self.logger.info("Search complete")
         self.logger.info(f"Number of results found: {len(res)}")
+
+        if res.wcs is None:
+            self.logger.warning("Results WCS is None. Adding from resampled WorkUnit.")
+            res.wcs = wu.wcs
+
+        # Drop everything after collection from wu_filename
+        injection_cat_filename = wu_filename[wu_filename.find("collection") :] + ".injection_cat.parquet"
+        injection_cat_path = os.path.join(directory_containing_shards, injection_cat_filename)
+        # Match injection results here since injection catalogs are per-image collection, and it only makes
+        # sense to match them on a per-results file basis.
+        res_with_match, recovered, missed = match_injection_results(
+            catalog=injection_cat_path,
+            results=res,
+            guess_distance=wu.barycentric_distance,
+            sep_thresh=5.0,  # arcsec
+            min_obs=3,  # min matching obs for recovery
+        )
+
+        res = res_with_match
+        self.logger.info(f"Recovered {recovered} injected objects from {len(res)} results.")
+        self.logger.info(f"Missed {missed} injected objects from {len(res)} results.")
 
         self.logger.info(f"Writing results to output file: {self.result_filepath}")
         res.write_table(self.result_filepath)

--- a/src/kbmod_wf/task_impls/kbmod_search.py
+++ b/src/kbmod_wf/task_impls/kbmod_search.py
@@ -111,22 +111,41 @@ class KBMODSearcher:
             self.logger.warning("Results WCS is None. Adding from resampled WorkUnit.")
             res.wcs = wu.wcs
 
-        # Drop everything after collection from wu_filename
-        injection_cat_filename = wu_filename[wu_filename.find("collection") :] + ".injection_cat.parquet"
+        # Extract the original collection filename by removing the ".wu.{dist}.repro" suffix
+        # e.g., "468929_65.0_20X20_0_to_99.collection.wu.65.0.repro" -> "468929_65.0_20X20_0_to_99.collection"
+        wu_suffix_start = wu_filename.find(".wu.")
+        if wu_suffix_start != -1:
+            collection_filename = wu_filename[:wu_suffix_start]
+        else:
+            # Fallback: use the full filename if ".wu." not found
+            collection_filename = wu_filename
+        injection_cat_filename = collection_filename + ".injection_cat.parquet"
         injection_cat_path = os.path.join(directory_containing_shards, injection_cat_filename)
-        # Match injection results here since injection catalogs are per-image collection, and it only makes
-        # sense to match them on a per-results file basis.
-        res_with_match, recovered, missed = match_injection_results(
-            catalog=injection_cat_path,
-            results=res,
-            guess_distance=wu.barycentric_distance,
-            sep_thresh=5.0,  # arcsec
-            min_obs=3,  # min matching obs for recovery
-        )
 
-        res = res_with_match
-        self.logger.info(f"Recovered {recovered} injected objects from {len(res)} results.")
-        self.logger.info(f"Missed {missed} injected objects from {len(res)} results.")
+        # Match injection results if catalog exists (injection was performed)
+        if os.path.exists(injection_cat_path):
+            self.logger.info(f"Found injection catalog: {injection_cat_path}")
+            res_with_match, recovered, missed = match_injection_results(
+                catalog=injection_cat_path,
+                results=res,
+                guess_distance=wu.barycentric_distance,
+                sep_thresh=5.0,  # arcsec
+                min_obs=3,  # min matching obs for recovery
+            )
+            res = res_with_match
+            self.logger.info(f"Recovered {len(recovered)} injected objects from {len(res)} results.")
+            self.logger.info(f"Missed {len(missed)} injected objects from {len(res)} results.")
+
+            # Convert dict/list columns to JSON strings for parquet serialization
+            import json
+
+            for col in ["injected_sources", "recovered_injected_sources_min_obs_3"]:
+                if col in res.table.colnames:
+                    res.table[col] = [json.dumps(d) if d else "" for d in res.table[col]]
+        else:
+            self.logger.info(
+                f"No injection catalog found at {injection_cat_path}, skipping injection matching."
+            )
 
         self.logger.info(f"Writing results to output file: {self.result_filepath}")
         res.write_table(self.result_filepath)

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -89,6 +89,7 @@ class WUReprojector:
             save=False,
             runtime_config=self.runtime_config,
             logger=self.logger,
+            guess_dist=self.guess_dist,
         )
         elapsed = round(time.time() - last_time, 1)
         self.logger.debug(

--- a/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
+++ b/src/kbmod_wf/task_impls/reproject_multi_chip_multi_night_wu.py
@@ -125,12 +125,8 @@ class WUReprojector:
         # Use the global WCS that was specified from the ImageCollection.
         ic = ImageCollection.read(self.ic_filepath, format="ascii.ecsv")
 
-        # Pick the first global WCS and pixel shape from the ImageCollection
-        common_wcs = WCS(ic.data["global_wcs"][0])
-        common_wcs.pixel_shape = (
-            ic.data["global_wcs_pixel_shape_0"][0],
-            ic.data["global_wcs_pixel_shape_1"][0],
-        )
+        # Pick the global WCS from the ImageCollection, or auto-fit if none exist
+        common_wcs = ic.get_global_wcs(auto_fit=False)
 
         resampled_wu = reprojection.reproject_work_unit(
             wu,


### PR DESCRIPTION
Adds support generating or using catalogs of synthetic objects for source injections into ImageCollections, utilizing the KBMOD injection module added in https://github.com/dirac-institute/kbmod/pull/1139 

Adds the following configurations:

| Config Key                | Type    | Default      | Description                                                                                                                     |
  |---------------------------|---------|--------------|---------------------------------------------------------------------------------------------------------------------------------|
  | [apps.ic_to_wu.injection] | section | —            | Injection configuration section                                                                                                 |
  | n_objs_per_ic             | int     | 50           | Number of synthetic objects to inject per ImageCollection                                                                       |
  | mag_range                 | list    | [19.0, 26.0] | Magnitude range [min, max] for injected objects                                                                                 |
  | catalog_mapping_path      | str     | None         | Path to parquet file mapping IC paths to pre-computed catalog paths. If specified and a match is found, generation is bypassed. |

  Catalog mapping parquet schema:
  | Column           | Type | Description                                                         |
  |------------------|------|---------------------------------------------------------------------|
  | ic_filepath      | str  | Path to the ImageCollection file                                    |
  | catalog_filepath | str  | Path to the corresponding injection catalog (.parquet, .ecsv, etc.) | 

This also includes some changes from @ColinOrionChandler 's USDF resource configuration